### PR TITLE
Find element by path

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -598,6 +598,11 @@ export class ElementDefinition {
     const slice = this.clone(true);
     slice.id = `${this.id}:${name}`;
     slice.sliceName = name;
+    // When a choice is sliced, we do not inherit min cardinality, but rather make it 0
+    // According to https://chat.fhir.org/#narrow/stream/179239-tooling/topic/Slicing.201.2E.2E.3F.20element
+    if (this.id.endsWith('[x]')) {
+      slice.min = 0;
+    }
     if (type) {
       slice.type = [type];
     } else {

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -95,18 +95,21 @@ export class ElementDefinition {
     this.path = this._id
       .split('.')
       .map(s => {
-        // Usually the path part is just the name without the slice. The one exception is parts representing
+        // Usually the path part is just the name without the slice.
+        const [name] = s.split(':', 2);
+        // The spec is unclear on if there is an exception in parts representing
         // a specific choice type, in which case, the path is the slice name (e.g., ) if the id is
-        // Observation.value[x]:valueQuantity, then path is Observation.valueQuantity
-        const [name, slice] = s.split(':', 2);
-        if (
-          slice &&
-          name.endsWith('[x]') &&
-          this.type &&
-          this.type.some(t => slice === `${name.slice(0, -3)}${capitalize(t.code)}`)
-        ) {
-          return slice;
-        }
+        // Observation.value[x]:valueQuantity, then path is Observation.valueQuantity.
+        // The code to make the exception is commented below, and will remain until we can clarify
+        // const [name, slice] = s.split(':', 2);
+        // if (
+        //   slice &&
+        //   name.endsWith('[x]') &&
+        //   this.type &&
+        //   this.type.some(t => slice === `${name.slice(0, -3)}${capitalize(t.code)}`)
+        // ) {
+        //   return slice;
+        // }
         return name;
       })
       .join('.');

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -299,6 +299,9 @@ export class StructureDefinition {
     });
     if (matchingXElement) {
       // If we find a matching [x] element, we need to slice it to create the child element
+      // NOTE: The spec is somewhat incosistent on handling choice slicing, we decided on this
+      // approach per consistency with 4.0.1 observation-vitalsigns profiles and per this post
+      // https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/.
       matchingXElement.sliceIt('type', '$this', false, 'open');
       // Get the sliceName for the new element
       const sliceName = fhirPath.slice(fhirPath.lastIndexOf('.') + 1);
@@ -315,6 +318,10 @@ export class StructureDefinition {
    * @returns {ElementDefinition} - The sliceElement if found, else undefined
    */
   private findMatchingSlice(pathPart: PathPart, elements: ElementDefinition[]): ElementDefinition {
+    // NOTE: This function will assume the 'brackets' field contains information about slices. Even
+    // if you search for foo[sliceName][refName], this will try to find a re-slice
+    // sliceName/refName. To find the matching element for foo[sliceName][refName], you must
+    // use the findMatchingRef function. Be aware of this ambiguity in the bracket path syntax.
     return elements.find(e => e.sliceName === pathPart.brackets.join('/'));
   }
 

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -342,7 +342,15 @@ export class StructureDefinition {
           return (
             t.code === 'Reference' &&
             t.targetProfile &&
-            t.targetProfile.find(tp => tp.endsWith(`/${pathPart.brackets[0]}`))
+            t.targetProfile.find(tp => {
+              const refName = pathPart.brackets.slice(-1)[0];
+              // Slice to get last part of url
+              // http://hl7.org/fhir/us/core/StructureDefinition/profile|3.0.0 -> profile|3.0.0
+              let tpRefName = tp.split('/').slice(-1)[0];
+              // Slice to get rid of version, profile|3.0.0 -> profile
+              tpRefName = tpRefName.split('|')[0];
+              return tpRefName === refName;
+            })
           );
         }
       }

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -335,7 +335,7 @@ export class StructureDefinition {
           return (
             t.code === 'Reference' &&
             t.targetProfile &&
-            t.targetProfile.find(tp => tp.endsWith(pathPart.brackets[0]))
+            t.targetProfile.find(tp => tp.endsWith(`/${pathPart.brackets[0]}`))
           );
         }
       }

--- a/test/fhirdefs/testdefs/patient-telecom-reslice-profile.json
+++ b/test/fhirdefs/testdefs/patient-telecom-reslice-profile.json
@@ -1,0 +1,9241 @@
+{
+    "baseDefinition": "http://example.com/fhir/SD/patient-name-slice",
+    "type": "Patient",
+    "differential": {
+      "element": [
+        {
+          "slicing": {
+            "rules": "open",
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "system"
+              }
+            ]
+          },
+          "path": "Patient.telecom"
+        },
+        {
+          "sliceName": "phone",
+          "path": "Patient.telecom",
+          "slicing": {
+            "rules": "open",
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "use"
+              }
+            ]
+          },
+          "short": "Phone numbers."
+        },
+        {
+          "min": 1,
+          "path": "Patient.telecom.system",
+          "fixedCode": "phone"
+        },
+        {
+          "min": 1,
+          "path": "Patient.telecom.use",
+          "fixedCode": "home"
+        },
+        {
+          "min": 1,
+          "path": "Patient.telecom.use",
+          "fixedCode": "mobile"
+        },
+        {
+          "sliceName": "email",
+          "path": "Patient.telecom",
+          "slicing": {
+            "rules": "open",
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "use"
+              }
+            ]
+          }
+        },
+        {
+          "min": 1,
+          "path": "Patient.telecom.system",
+          "fixedCode": "email"
+        },
+        {
+          "min": 1,
+          "path": "Patient.telecom.use",
+          "fixedCode": "work"
+        },
+        {
+          "min": 1,
+          "path": "Patient.telecom.use",
+          "fixedCode": "home"
+        },
+        {
+          "min": 1,
+          "path": "Patient.telecom.system",
+          "fixedCode": "pager"
+        }
+      ]
+    },
+    "abstract": false,
+    "snapshot": {
+      "element": [
+        {
+          "alias": [
+            "SubjectOfCare Client Resident"
+          ],
+          "definition": "Demographics and other administrative information about an individual or animal receiving care or other health-related services.",
+          "short": "Information about an individual or animal receiving health care services",
+          "constraint": [
+            {
+              "xpath": "not(parent::f:contained and f:contained)",
+              "key": "dom-2",
+              "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+              "severity": "error"
+            },
+            {
+              "xpath": "not(parent::f:contained and f:text)",
+              "key": "dom-1",
+              "human": "If the resource is contained in another resource, it SHALL NOT contain any narrative",
+              "severity": "error"
+            },
+            {
+              "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+              "key": "dom-4",
+              "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+              "severity": "error"
+            },
+            {
+              "xpath": "not(exists(for $id in f:contained/*/@id return $id[not(ancestor::f:contained/parent::*/descendant::f:reference/@value=concat('#', $id))]))",
+              "key": "dom-3",
+              "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "Patient[classCode=PAT]"
+            },
+            {
+              "identity": "cda",
+              "map": "ClinicalDocument.recordTarget.patientRole"
+            },
+            {
+              "identity": "w5",
+              "map": "administrative.individual"
+            },
+            {
+              "identity": "rim",
+              "map": "Entity. Role, or Act"
+            },
+            {
+              "identity": "rim",
+              "map": "Entity. Role, or Act"
+            }
+          ],
+          "type": [
+            {
+              "code": "DomainResource"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Patient",
+            "max": "*"
+          },
+          "path": "Patient"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Resource.id",
+            "max": "1"
+          },
+          "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+          "short": "Logical id of this artifact",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation. Bundles always have an id, though it is usually a generated UUID.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.id"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Resource.meta",
+            "max": "1"
+          },
+          "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content may not always be associated with version changes to the resource.",
+          "short": "Metadata about the resource",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "Meta"
+            }
+          ],
+          "path": "Patient.meta"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Resource.implicitRules",
+            "max": "1"
+          },
+          "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "A set of rules under which this content was created",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element as much as possible.",
+          "condition": [
+            "ele-1"
+          ],
+          "isModifier": true,
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "path": "Patient.implicitRules"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Resource.language",
+            "max": "1"
+          },
+          "definition": "The base language in which the resource is written.",
+          "short": "Language of the resource content",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource  Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "binding": {
+            "valueSetUri": "http://tools.ietf.org/html/bcp47",
+            "description": "A human language.",
+            "strength": "required"
+          },
+          "condition": [
+            "ele-1"
+          ],
+          "max": "1",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "path": "Patient.language"
+        },
+        {
+          "alias": [
+            "narrative",
+            "html",
+            "xhtml",
+            "display"
+          ],
+          "definition": "A human-readable narrative that contains a summary of the resource, and may be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+          "short": "Text summary of the resource, for human interpretation",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "Act.text?"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "dom-1",
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Narrative"
+            }
+          ],
+          "max": "1",
+          "base": {
+            "min": 0,
+            "path": "DomainResource.text",
+            "max": "1"
+          },
+          "path": "Patient.text"
+        },
+        {
+          "alias": [
+            "inline resources",
+            "anonymous resources",
+            "contained resources"
+          ],
+          "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+          "short": "Contained, inline Resources",
+          "min": 0,
+          "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "Entity. Role, or Act"
+            }
+          ],
+          "type": [
+            {
+              "code": "Resource"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "DomainResource.contained",
+            "max": "*"
+          },
+          "path": "Patient.contained"
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the resource. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "DomainResource.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension"
+        },
+        {
+          "requirements": "Requirements for do not call flag root element.",
+          "alias": [
+            "no-contact-me-plz"
+          ],
+          "sliceName": "doNotCall",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            }
+          ],
+          "short": "Do not call flag.",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Comments for do not call flag root element.",
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension",
+              "profile": "http://example.com/fhir/StructureDefinition/patient-do-not-call"
+            }
+          ],
+          "base": {
+            "min": 0,
+            "path": "DomainResource.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension",
+          "max": "*",
+          "definition": "A flag indicating that a patient has requested their contact information be added to the do-not-call list."
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.extension.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension.extension"
+        },
+        {
+          "base": {
+            "min": 1,
+            "path": "Extension.url",
+            "max": "1"
+          },
+          "definition": "Source of the definition for the extension code - a logical name or a URL.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "identifies the meaning of the extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #.",
+          "condition": [
+            "ele-1"
+          ],
+          "fixedUri": "http://example.com/fhir/StructureDefinition/patient-do-not-call",
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "path": "Patient.extension.url",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Extension.value[x]",
+            "max": "1"
+          },
+          "definition": "Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list).",
+          "short": "Value of extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "max": "1",
+          "type": [
+            {
+              "code": "boolean"
+            }
+          ],
+          "path": "Patient.extension.value[x]"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "DomainResource.extension",
+            "max": "*"
+          },
+          "sliceName": "legalCase",
+          "label": "Legal Case Flag",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension",
+              "profile": "http://example.com/fhir/StructureDefinition/patient-legal-case"
+            }
+          ],
+          "definition": "A flag indicating that a patient is involved in a legal dispute with the enterprise.",
+          "path": "Patient.extension",
+          "max": "*",
+          "short": "Base for all elements"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.extension.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension.extension"
+        },
+        {
+          "base": {
+            "min": 1,
+            "path": "Extension.url",
+            "max": "1"
+          },
+          "definition": "Source of the definition for the extension code - a logical name or a URL.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "identifies the meaning of the extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #.",
+          "condition": [
+            "ele-1"
+          ],
+          "fixedUri": "http://example.com/fhir/StructureDefinition/patient-legal-case",
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "path": "Patient.extension.url",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Extension.value[x]",
+            "max": "1"
+          },
+          "definition": "Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list).",
+          "short": "Value of extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "max": "1",
+          "type": [
+            {
+              "code": "boolean"
+            }
+          ],
+          "path": "Patient.extension.value[x]"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.extension.value[x].id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension.value[x].extension"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Extension.value[x]",
+            "max": "1"
+          },
+          "definition": "Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list).",
+          "short": "Value of extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "max": "1",
+          "type": [
+            {
+              "code": "boolean"
+            }
+          ],
+          "path": "Patient.extension.valueBoolean"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.extension.valueBoolean.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension.valueBoolean.extension"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Extension",
+            "max": "*"
+          },
+          "definition": "Identification of the the legal counsel assigned to the case in question.",
+          "label": "Lead Counsel",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension",
+              "profile": "http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel"
+            }
+          ],
+          "path": "Patient.extension.valueBoolean.extension",
+          "max": "*",
+          "short": "Base for all elements"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.extension.valueBoolean.extension.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension.valueBoolean.extension.extension"
+        },
+        {
+          "base": {
+            "min": 1,
+            "path": "Extension.url",
+            "max": "1"
+          },
+          "definition": "Source of the definition for the extension code - a logical name or a URL.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "identifies the meaning of the extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #.",
+          "condition": [
+            "ele-1"
+          ],
+          "fixedUri": "http://example.com/fhir/StructureDefinition/patient-legal-case-lead-counsel",
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "path": "Patient.extension.valueBoolean.extension.url",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Extension.value[x]",
+            "max": "1"
+          },
+          "definition": "Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list).",
+          "short": "Value of extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "max": "1",
+          "type": [
+            {
+              "code": "boolean"
+            },
+            {
+              "code": "integer"
+            },
+            {
+              "code": "decimal"
+            },
+            {
+              "code": "base64Binary"
+            },
+            {
+              "code": "instant"
+            },
+            {
+              "code": "string"
+            },
+            {
+              "code": "uri"
+            },
+            {
+              "code": "date"
+            },
+            {
+              "code": "dateTime"
+            },
+            {
+              "code": "time"
+            },
+            {
+              "code": "code"
+            },
+            {
+              "code": "oid"
+            },
+            {
+              "code": "id"
+            },
+            {
+              "code": "unsignedInt"
+            },
+            {
+              "code": "positiveInt"
+            },
+            {
+              "code": "markdown"
+            },
+            {
+              "code": "Annotation"
+            },
+            {
+              "code": "Attachment"
+            },
+            {
+              "code": "Identifier"
+            },
+            {
+              "code": "CodeableConcept"
+            },
+            {
+              "code": "Coding"
+            },
+            {
+              "code": "Quantity"
+            },
+            {
+              "code": "Range"
+            },
+            {
+              "code": "Period"
+            },
+            {
+              "code": "Ratio"
+            },
+            {
+              "code": "SampledData"
+            },
+            {
+              "code": "Signature"
+            },
+            {
+              "code": "Reference"
+            },
+            {
+              "code": "HumanName"
+            },
+            {
+              "code": "Address"
+            },
+            {
+              "code": "ContactPoint"
+            },
+            {
+              "code": "Timing"
+            },
+            {
+              "code": "Meta"
+            }
+          ],
+          "path": "Patient.extension.valueBoolean.extension.value[x]"
+        },
+        {
+          "min": 0,
+          "max": "1",
+          "base": {
+            "min": 0,
+            "path": "boolean.value",
+            "max": "1"
+          },
+          "definition": "Primitive value for boolean",
+          "path": "Patient.extension.valueBoolean.value",
+          "short": "Primitive value for boolean",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "DomainResource.extension",
+            "max": "*"
+          },
+          "sliceName": "religion",
+          "label": "Patient Religion",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension",
+              "profile": "http://hl7.org/fhir/StructureDefinition/us-core-religion"
+            }
+          ],
+          "definition": "A code classifying a person's professed religion.",
+          "path": "Patient.extension",
+          "max": "*",
+          "short": "Patient's professed religious affiliation"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.extension.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "0",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension.extension"
+        },
+        {
+          "base": {
+            "min": 1,
+            "path": "Extension.url",
+            "max": "1"
+          },
+          "definition": "Source of the definition for the extension code - a logical name or a URL.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "identifies the meaning of the extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #.",
+          "condition": [
+            "ele-1"
+          ],
+          "fixedUri": "http://hl7.org/fhir/StructureDefinition/us-core-religion",
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "path": "Patient.extension.url",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Extension.value[x]",
+            "max": "1"
+          },
+          "definition": "Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list).",
+          "short": "Value of extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/v3-ReligiousAffiliation",
+            "description": "A code classifying a person's professed religion",
+            "strength": "required"
+          },
+          "condition": [
+            "ele-1"
+          ],
+          "max": "1",
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "path": "Patient.extension.value[x]"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "DomainResource.extension",
+            "max": "*"
+          },
+          "sliceName": "researchAuth",
+          "short": "Base for all elements",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension",
+              "profile": "http://example.com/fhir/StructureDefinition/patient-research-authorization"
+            }
+          ],
+          "path": "Patient.extension",
+          "max": "*",
+          "definition": "Record of the patients general research authorization status."
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.extension.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension.extension"
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "1",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension.extension"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.extension.extension.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension.extension.extension"
+        },
+        {
+          "base": {
+            "min": 1,
+            "path": "Extension.url",
+            "max": "1"
+          },
+          "definition": "Source of the definition for the extension code - a logical name or a URL.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "identifies the meaning of the extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #.",
+          "condition": [
+            "ele-1"
+          ],
+          "fixedUri": "type",
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "path": "Patient.extension.extension.url",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Extension.value[x]",
+            "max": "1"
+          },
+          "definition": "Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list).",
+          "short": "Value of extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "max": "1",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "path": "Patient.extension.extension.value[x]"
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "1",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension.extension"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.extension.extension.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension.extension.extension"
+        },
+        {
+          "base": {
+            "min": 1,
+            "path": "Extension.url",
+            "max": "1"
+          },
+          "definition": "Source of the definition for the extension code - a logical name or a URL.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "identifies the meaning of the extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #.",
+          "condition": [
+            "ele-1"
+          ],
+          "fixedUri": "flag",
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "path": "Patient.extension.extension.url",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Extension.value[x]",
+            "max": "1"
+          },
+          "definition": "Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list).",
+          "short": "Value of extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "max": "1",
+          "type": [
+            {
+              "code": "boolean"
+            },
+            {
+              "code": "integer"
+            },
+            {
+              "code": "decimal"
+            },
+            {
+              "code": "base64Binary"
+            },
+            {
+              "code": "instant"
+            },
+            {
+              "code": "string"
+            },
+            {
+              "code": "uri"
+            },
+            {
+              "code": "date"
+            },
+            {
+              "code": "dateTime"
+            },
+            {
+              "code": "time"
+            },
+            {
+              "code": "code"
+            },
+            {
+              "code": "oid"
+            },
+            {
+              "code": "id"
+            },
+            {
+              "code": "unsignedInt"
+            },
+            {
+              "code": "positiveInt"
+            },
+            {
+              "code": "markdown"
+            },
+            {
+              "code": "Annotation"
+            },
+            {
+              "code": "Attachment"
+            },
+            {
+              "code": "Identifier"
+            },
+            {
+              "code": "CodeableConcept"
+            },
+            {
+              "code": "Coding"
+            },
+            {
+              "code": "Quantity"
+            },
+            {
+              "code": "Range"
+            },
+            {
+              "code": "Period"
+            },
+            {
+              "code": "Ratio"
+            },
+            {
+              "code": "SampledData"
+            },
+            {
+              "code": "Signature"
+            },
+            {
+              "code": "Reference"
+            },
+            {
+              "code": "HumanName"
+            },
+            {
+              "code": "Address"
+            },
+            {
+              "code": "ContactPoint"
+            },
+            {
+              "code": "Timing"
+            },
+            {
+              "code": "Meta"
+            }
+          ],
+          "path": "Patient.extension.extension.value[x]"
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "1",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension.extension"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.extension.extension.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.extension.extension.extension"
+        },
+        {
+          "base": {
+            "min": 1,
+            "path": "Extension.url",
+            "max": "1"
+          },
+          "definition": "Source of the definition for the extension code - a logical name or a URL.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "identifies the meaning of the extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #.",
+          "condition": [
+            "ele-1"
+          ],
+          "fixedUri": "date",
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "path": "Patient.extension.extension.url",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Extension.value[x]",
+            "max": "1"
+          },
+          "definition": "Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list).",
+          "short": "Value of extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "max": "1",
+          "type": [
+            {
+              "code": "boolean"
+            },
+            {
+              "code": "integer"
+            },
+            {
+              "code": "decimal"
+            },
+            {
+              "code": "base64Binary"
+            },
+            {
+              "code": "instant"
+            },
+            {
+              "code": "string"
+            },
+            {
+              "code": "uri"
+            },
+            {
+              "code": "date"
+            },
+            {
+              "code": "dateTime"
+            },
+            {
+              "code": "time"
+            },
+            {
+              "code": "code"
+            },
+            {
+              "code": "oid"
+            },
+            {
+              "code": "id"
+            },
+            {
+              "code": "unsignedInt"
+            },
+            {
+              "code": "positiveInt"
+            },
+            {
+              "code": "markdown"
+            },
+            {
+              "code": "Annotation"
+            },
+            {
+              "code": "Attachment"
+            },
+            {
+              "code": "Identifier"
+            },
+            {
+              "code": "CodeableConcept"
+            },
+            {
+              "code": "Coding"
+            },
+            {
+              "code": "Quantity"
+            },
+            {
+              "code": "Range"
+            },
+            {
+              "code": "Period"
+            },
+            {
+              "code": "Ratio"
+            },
+            {
+              "code": "SampledData"
+            },
+            {
+              "code": "Signature"
+            },
+            {
+              "code": "Reference"
+            },
+            {
+              "code": "HumanName"
+            },
+            {
+              "code": "Address"
+            },
+            {
+              "code": "ContactPoint"
+            },
+            {
+              "code": "Timing"
+            },
+            {
+              "code": "Meta"
+            }
+          ],
+          "path": "Patient.extension.extension.value[x]"
+        },
+        {
+          "base": {
+            "min": 1,
+            "path": "Extension.url",
+            "max": "1"
+          },
+          "definition": "Source of the definition for the extension code - a logical name or a URL.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "identifies the meaning of the extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #.",
+          "condition": [
+            "ele-1"
+          ],
+          "fixedUri": "http://example.com/fhir/StructureDefinition/patient-research-authorization",
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "path": "Patient.extension.url",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Extension.value[x]",
+            "max": "1"
+          },
+          "definition": "Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list).",
+          "short": "Value of extension",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "max": "1",
+          "type": [
+            {
+              "code": "boolean"
+            },
+            {
+              "code": "integer"
+            },
+            {
+              "code": "decimal"
+            },
+            {
+              "code": "base64Binary"
+            },
+            {
+              "code": "instant"
+            },
+            {
+              "code": "string"
+            },
+            {
+              "code": "uri"
+            },
+            {
+              "code": "date"
+            },
+            {
+              "code": "dateTime"
+            },
+            {
+              "code": "time"
+            },
+            {
+              "code": "code"
+            },
+            {
+              "code": "oid"
+            },
+            {
+              "code": "id"
+            },
+            {
+              "code": "unsignedInt"
+            },
+            {
+              "code": "positiveInt"
+            },
+            {
+              "code": "markdown"
+            },
+            {
+              "code": "Annotation"
+            },
+            {
+              "code": "Attachment"
+            },
+            {
+              "code": "Identifier"
+            },
+            {
+              "code": "CodeableConcept"
+            },
+            {
+              "code": "Coding"
+            },
+            {
+              "code": "Quantity"
+            },
+            {
+              "code": "Range"
+            },
+            {
+              "code": "Period"
+            },
+            {
+              "code": "Ratio"
+            },
+            {
+              "code": "SampledData"
+            },
+            {
+              "code": "Signature"
+            },
+            {
+              "code": "Reference"
+            },
+            {
+              "code": "HumanName"
+            },
+            {
+              "code": "Address"
+            },
+            {
+              "code": "ContactPoint"
+            },
+            {
+              "code": "Timing"
+            },
+            {
+              "code": "Meta"
+            }
+          ],
+          "path": "Patient.extension.value[x]"
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the resource, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Extensions that cannot be ignored",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "isModifier": true,
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "DomainResource.modifierExtension",
+            "max": "*"
+          },
+          "path": "Patient.modifierExtension"
+        },
+        {
+          "requirements": "Patients are almost always assigned specific numerical identifiers.",
+          "base": {
+            "min": 0,
+            "path": "Patient.identifier",
+            "max": "*"
+          },
+          "definition": "An identifier for this patient.",
+          "short": "An identifier for this patient",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-3"
+            },
+            {
+              "identity": "rim",
+              "map": "id"
+            },
+            {
+              "identity": "cda",
+              "map": ".id"
+            },
+            {
+              "identity": "w5",
+              "map": "id"
+            },
+            {
+              "identity": "v2",
+              "map": "CX / EI (occasionally, more often EI maps to a resource id or a URL)"
+            },
+            {
+              "identity": "rim",
+              "map": "II - see see identifier pattern at http://wiki.hl7.org/index.php?title=Common_Design_Patterns#Identifier_Pattern for relevant discussion. The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]"
+            },
+            {
+              "identity": "servd",
+              "map": "Identifier"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.identifier",
+          "type": [
+            {
+              "code": "Identifier"
+            }
+          ],
+          "max": "*"
+        },
+        {
+          "requirements": "Need to be able to mark a patient record as not to be used because it was created in error.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "statusCode"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "w5",
+              "map": "status"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "base": {
+            "min": 0,
+            "path": "Patient.active",
+            "max": "1"
+          },
+          "definition": "Whether this patient record is in active use.",
+          "condition": [
+            "ele-1"
+          ],
+          "short": "Whether this patient's record is in active use",
+          "defaultValueBoolean": true,
+          "min": 0,
+          "comment": "Default is true. If a record is inactive, and linked to an active record, then future patient/record updates should occur on the other patient.",
+          "isModifier": true,
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "isSummary": true,
+          "path": "Patient.active",
+          "type": [
+            {
+              "code": "boolean"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "Need to be able to track the patient by multiple names. Examples are your official name and a partner name.",
+          "slicing": {
+            "rules": "open",
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "use"
+              }
+            ]
+          },
+          "base": {
+            "min": 0,
+            "path": "Patient.name",
+            "max": "*"
+          },
+          "definition": "A name associated with the individual.",
+          "short": "A name associated with the patient",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "A patient may have multiple names with different uses or applicable periods. For animals, the name is a \"HumanName\" in the sense that is assigned and used by humans and has the same patterns.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-5, PID-9"
+            },
+            {
+              "identity": "rim",
+              "map": "name"
+            },
+            {
+              "identity": "cda",
+              "map": ".patient.name"
+            },
+            {
+              "identity": "v2",
+              "map": "XPN"
+            },
+            {
+              "identity": "rim",
+              "map": "EN (actually, PN)"
+            },
+            {
+              "identity": "servd",
+              "map": "ProviderName"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.name",
+          "type": [
+            {
+              "code": "HumanName"
+            }
+          ],
+          "max": "*"
+        },
+        {
+          "requirements": "Need to be able to track the patient by multiple names. Examples are your official name and a partner name.",
+          "base": {
+            "min": 0,
+            "path": "Patient.name",
+            "max": "*"
+          },
+          "sliceName": "officialName",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-5, PID-9"
+            },
+            {
+              "identity": "rim",
+              "map": "name"
+            },
+            {
+              "identity": "cda",
+              "map": ".patient.name"
+            },
+            {
+              "identity": "v2",
+              "map": "XPN"
+            },
+            {
+              "identity": "rim",
+              "map": "EN (actually, PN)"
+            },
+            {
+              "identity": "servd",
+              "map": "ProviderName"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "A name associated with the patient",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "A patient may have multiple names with different uses or applicable periods. For animals, the name is a \"HumanName\" in the sense that is assigned and used by humans and has the same patterns.",
+          "type": [
+            {
+              "code": "HumanName"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.name",
+          "max": "1",
+          "definition": "A name associated with the individual."
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.name.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.name.extension"
+        },
+        {
+          "requirements": "Allows the appropriate name for a particular context of use to be selected from among a set of names.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XPN.7, but often indicated by which field contains the name"
+            },
+            {
+              "identity": "rim",
+              "map": "unique(./use)"
+            },
+            {
+              "identity": "servd",
+              "map": "./NamePurpose"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "fixedCode": "official",
+          "base": {
+            "min": 0,
+            "path": "HumanName.use",
+            "max": "1"
+          },
+          "definition": "Identifies the purpose for this name.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/name-use",
+            "description": "The use of a human name",
+            "strength": "required"
+          },
+          "short": "usual | official | temp | nickname | anonymous | old | maiden",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old.",
+          "condition": [
+            "ele-1"
+          ],
+          "isModifier": true,
+          "isSummary": true,
+          "path": "Patient.name.use",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "A renderable, unencoded form.",
+          "base": {
+            "min": 0,
+            "path": "HumanName.text",
+            "max": "1"
+          },
+          "definition": "A full text representation of the name.",
+          "short": "Text representation of the full name",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "Can provide both a text representation and structured parts.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "implied by XPN.11"
+            },
+            {
+              "identity": "rim",
+              "map": "./formatted"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.name.text",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "alias": [
+            "surname"
+          ],
+          "definition": "The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XPN.1"
+            },
+            {
+              "identity": "rim",
+              "map": "./part[partType = FAM]"
+            },
+            {
+              "identity": "servd",
+              "map": "./FamilyName"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Family name (often called 'Surname')",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "For family name, hyphenated names such as \"Smith-Jones\" are a single name, but names with spaces such as \"Smith Jones\" are broken into multiple parts.",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "HumanName.family",
+            "max": "*"
+          },
+          "path": "Patient.name.family"
+        },
+        {
+          "alias": [
+            "first name",
+            "middle name"
+          ],
+          "definition": "Given name.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XPN.2 + XPN.3"
+            },
+            {
+              "identity": "rim",
+              "map": "./part[partType = GIV]"
+            },
+            {
+              "identity": "servd",
+              "map": "./GivenNames"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Given names (not always 'first'). Includes middle names",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "If only initials are recorded, they may be used in place of the full name.  Not called \"first name\" since given names do not always come first.",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "HumanName.given",
+            "max": "*"
+          },
+          "path": "Patient.name.given"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "HumanName.prefix",
+            "max": "*"
+          },
+          "definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.",
+          "short": "Parts that come before the name",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that FHIR strings may not exceed 1MB in size",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XPN.5"
+            },
+            {
+              "identity": "rim",
+              "map": "./part[partType = PFX]"
+            },
+            {
+              "identity": "servd",
+              "map": "./TitleCode"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "*",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "path": "Patient.name.prefix"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "HumanName.suffix",
+            "max": "*"
+          },
+          "definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.",
+          "short": "Parts that come after the name",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that FHIR strings may not exceed 1MB in size",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XPN/4"
+            },
+            {
+              "identity": "rim",
+              "map": "./part[partType = SFX]"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "*",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "path": "Patient.name.suffix"
+        },
+        {
+          "requirements": "Allows names to be placed in historical context.",
+          "base": {
+            "min": 0,
+            "path": "HumanName.period",
+            "max": "1"
+          },
+          "definition": "Indicates the period of time when this name was valid for the named person.",
+          "short": "Time period when name was/is in use",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:start)) or not(exists(f:end)) or (f:start/@value <= f:end/@value)",
+              "key": "per-1",
+              "human": "If present, start SHALL have a lower value than end",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This is not a duration - that's a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. \"the patient was an inpatient of the hospital for this time range\") or one value from the range applies (e.g. \"give to the patient between these two times\"). If duration is required, specify the type as Interval|Duration.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XPN.13 + XPN.14"
+            },
+            {
+              "identity": "rim",
+              "map": "./usablePeriod[type=\"IVL<TS>\"]"
+            },
+            {
+              "identity": "servd",
+              "map": "./StartDate and ./EndDate"
+            },
+            {
+              "identity": "v2",
+              "map": "DR"
+            },
+            {
+              "identity": "rim",
+              "map": "IVL<TS>[lowClosed=\"true\" and highClosed=\"true\"] or URG<TS>[lowClosed=\"true\" and highClosed=\"true\"]"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.name.period",
+          "type": [
+            {
+              "code": "Period"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "Need to be able to track the patient by multiple names. Examples are your official name and a partner name.",
+          "base": {
+            "min": 0,
+            "path": "Patient.name",
+            "max": "*"
+          },
+          "sliceName": "maidenName",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-5, PID-9"
+            },
+            {
+              "identity": "rim",
+              "map": "name"
+            },
+            {
+              "identity": "cda",
+              "map": ".patient.name"
+            },
+            {
+              "identity": "v2",
+              "map": "XPN"
+            },
+            {
+              "identity": "rim",
+              "map": "EN (actually, PN)"
+            },
+            {
+              "identity": "servd",
+              "map": "ProviderName"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "A name associated with the patient",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "A patient may have multiple names with different uses or applicable periods. For animals, the name is a \"HumanName\" in the sense that is assigned and used by humans and has the same patterns.",
+          "type": [
+            {
+              "code": "HumanName"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.name",
+          "max": "*",
+          "definition": "A name associated with the individual."
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.name.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.name.extension"
+        },
+        {
+          "requirements": "Allows the appropriate name for a particular context of use to be selected from among a set of names.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XPN.7, but often indicated by which field contains the name"
+            },
+            {
+              "identity": "rim",
+              "map": "unique(./use)"
+            },
+            {
+              "identity": "servd",
+              "map": "./NamePurpose"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "fixedCode": "maiden",
+          "base": {
+            "min": 0,
+            "path": "HumanName.use",
+            "max": "1"
+          },
+          "definition": "Identifies the purpose for this name.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/name-use",
+            "description": "The use of a human name",
+            "strength": "required"
+          },
+          "short": "usual | official | temp | nickname | anonymous | old | maiden",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old name etc.for a current/permanent one. Applications can assume that a name is current unless it explicitly says that it is temporary or old.",
+          "condition": [
+            "ele-1"
+          ],
+          "isModifier": true,
+          "isSummary": true,
+          "path": "Patient.name.use",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "A renderable, unencoded form.",
+          "base": {
+            "min": 0,
+            "path": "HumanName.text",
+            "max": "1"
+          },
+          "definition": "A full text representation of the name.",
+          "short": "Text representation of the full name",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Can provide both a text representation and structured parts.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "implied by XPN.11"
+            },
+            {
+              "identity": "rim",
+              "map": "./formatted"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.name.text",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "alias": [
+            "surname"
+          ],
+          "definition": "The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XPN.1"
+            },
+            {
+              "identity": "rim",
+              "map": "./part[partType = FAM]"
+            },
+            {
+              "identity": "servd",
+              "map": "./FamilyName"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Family name (often called 'Surname')",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "For family name, hyphenated names such as \"Smith-Jones\" are a single name, but names with spaces such as \"Smith Jones\" are broken into multiple parts.",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "HumanName.family",
+            "max": "*"
+          },
+          "path": "Patient.name.family"
+        },
+        {
+          "alias": [
+            "first name",
+            "middle name"
+          ],
+          "definition": "Given name.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XPN.2 + XPN.3"
+            },
+            {
+              "identity": "rim",
+              "map": "./part[partType = GIV]"
+            },
+            {
+              "identity": "servd",
+              "map": "./GivenNames"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Given names (not always 'first'). Includes middle names",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "If only initials are recorded, they may be used in place of the full name.  Not called \"first name\" since given names do not always come first.",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "HumanName.given",
+            "max": "*"
+          },
+          "path": "Patient.name.given"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "HumanName.prefix",
+            "max": "*"
+          },
+          "definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.",
+          "short": "Parts that come before the name",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that FHIR strings may not exceed 1MB in size",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XPN.5"
+            },
+            {
+              "identity": "rim",
+              "map": "./part[partType = PFX]"
+            },
+            {
+              "identity": "servd",
+              "map": "./TitleCode"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "*",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "path": "Patient.name.prefix"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "HumanName.suffix",
+            "max": "*"
+          },
+          "definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.",
+          "short": "Parts that come after the name",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that FHIR strings may not exceed 1MB in size",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XPN/4"
+            },
+            {
+              "identity": "rim",
+              "map": "./part[partType = SFX]"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "*",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "path": "Patient.name.suffix"
+        },
+        {
+          "requirements": "Allows names to be placed in historical context.",
+          "base": {
+            "min": 0,
+            "path": "HumanName.period",
+            "max": "1"
+          },
+          "definition": "Indicates the period of time when this name was valid for the named person.",
+          "short": "Time period when name was/is in use",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:start)) or not(exists(f:end)) or (f:start/@value <= f:end/@value)",
+              "key": "per-1",
+              "human": "If present, start SHALL have a lower value than end",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This is not a duration - that's a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. \"the patient was an inpatient of the hospital for this time range\") or one value from the range applies (e.g. \"give to the patient between these two times\"). If duration is required, specify the type as Interval|Duration.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XPN.13 + XPN.14"
+            },
+            {
+              "identity": "rim",
+              "map": "./usablePeriod[type=\"IVL<TS>\"]"
+            },
+            {
+              "identity": "servd",
+              "map": "./StartDate and ./EndDate"
+            },
+            {
+              "identity": "v2",
+              "map": "DR"
+            },
+            {
+              "identity": "rim",
+              "map": "IVL<TS>[lowClosed=\"true\" and highClosed=\"true\"] or URG<TS>[lowClosed=\"true\" and highClosed=\"true\"]"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.name.period",
+          "type": [
+            {
+              "code": "Period"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+          "slicing": {
+            "rules": "open",
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "system"
+              }
+            ]
+          },
+          "base": {
+            "min": 0,
+            "path": "Patient.telecom",
+            "max": "*"
+          },
+          "definition": "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted.",
+          "short": "A contact detail for the individual",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:value)) or exists(f:system)",
+              "key": "cpt-2",
+              "human": "A system is required if a value is provided.",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-13, PID-14, PID-40"
+            },
+            {
+              "identity": "rim",
+              "map": "telecom"
+            },
+            {
+              "identity": "cda",
+              "map": ".telecom"
+            },
+            {
+              "identity": "v2",
+              "map": "XTN"
+            },
+            {
+              "identity": "rim",
+              "map": "TEL"
+            },
+            {
+              "identity": "servd",
+              "map": "ContactPoint"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom",
+          "type": [
+            {
+              "code": "ContactPoint"
+            }
+          ],
+          "max": "*"
+        },
+        {
+          "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+          "slicing": {
+            "rules": "open",
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "use"
+              }
+            ]
+          },
+          "base": {
+            "min": 0,
+            "path": "Patient.telecom",
+            "max": "*"
+          },
+          "definition": "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-13, PID-14, PID-40"
+            },
+            {
+              "identity": "rim",
+              "map": "telecom"
+            },
+            {
+              "identity": "cda",
+              "map": ".telecom"
+            },
+            {
+              "identity": "v2",
+              "map": "XTN"
+            },
+            {
+              "identity": "rim",
+              "map": "TEL"
+            },
+            {
+              "identity": "servd",
+              "map": "ContactPoint"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Phone numbers.",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:value)) or exists(f:system)",
+              "key": "cpt-2",
+              "human": "A system is required if a value is provided.",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).",
+          "type": [
+            {
+              "code": "ContactPoint"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom",
+          "max": "*",
+          "sliceName": "phone"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.telecom.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.telecom.extension"
+        },
+        {
+          "fixedCode": "phone",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.system",
+            "max": "1"
+          },
+          "definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.3"
+            },
+            {
+              "identity": "rim",
+              "map": "./scheme"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointType"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "phone | fax | email | pager | other",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "Note that FHIR strings may not exceed 1MB in size",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-system",
+            "description": "Telecommunications form for contact point",
+            "strength": "required"
+          },
+          "condition": [
+            "cpt-2",
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "path": "Patient.telecom.system"
+        },
+        {
+          "requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.value",
+            "max": "1"
+          },
+          "definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
+          "short": "The actual contact point details",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.1 (or XTN.12)"
+            },
+            {
+              "identity": "rim",
+              "map": "./url"
+            },
+            {
+              "identity": "servd",
+              "map": "./Value"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom.value",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.2 - but often indicated by field"
+            },
+            {
+              "identity": "rim",
+              "map": "unique(./use)"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointPurpose"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.use",
+            "max": "1"
+          },
+          "definition": "Identifies the purpose for the contact point.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-use",
+            "description": "Use of contact point",
+            "strength": "required"
+          },
+          "short": "home | work | temp | old | mobile - purpose of this contact point",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
+          "condition": [
+            "ele-1"
+          ],
+          "isModifier": true,
+          "isSummary": true,
+          "path": "Patient.telecom.use",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.rank",
+            "max": "1"
+          },
+          "definition": "Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values.",
+          "short": "Specify preferred order of use (1 = highest)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "positiveInt"
+            }
+          ],
+          "path": "Patient.telecom.rank"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.period",
+            "max": "1"
+          },
+          "definition": "Time period when the contact point was/is in use.",
+          "short": "Time period when the contact point was/is in use",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:start)) or not(exists(f:end)) or (f:start/@value <= f:end/@value)",
+              "key": "per-1",
+              "human": "If present, start SHALL have a lower value than end",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This is not a duration - that's a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. \"the patient was an inpatient of the hospital for this time range\") or one value from the range applies (e.g. \"give to the patient between these two times\"). If duration is required, specify the type as Interval|Duration.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "./useablePeriod[type=\"IVL<TS>\"]"
+            },
+            {
+              "identity": "servd",
+              "map": "./StartDate and ./EndDate"
+            },
+            {
+              "identity": "v2",
+              "map": "DR"
+            },
+            {
+              "identity": "rim",
+              "map": "IVL<TS>[lowClosed=\"true\" and highClosed=\"true\"] or URG<TS>[lowClosed=\"true\" and highClosed=\"true\"]"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "Period"
+            }
+          ],
+          "path": "Patient.telecom.period"
+        },
+        {
+          "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+          "base": {
+            "min": 0,
+            "path": "Patient.telecom",
+            "max": "*"
+          },
+          "sliceName": "phone/homePhone",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-13, PID-14, PID-40"
+            },
+            {
+              "identity": "rim",
+              "map": "telecom"
+            },
+            {
+              "identity": "cda",
+              "map": ".telecom"
+            },
+            {
+              "identity": "v2",
+              "map": "XTN"
+            },
+            {
+              "identity": "rim",
+              "map": "TEL"
+            },
+            {
+              "identity": "servd",
+              "map": "ContactPoint"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Phone numbers.",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:value)) or exists(f:system)",
+              "key": "cpt-2",
+              "human": "A system is required if a value is provided.",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).",
+          "type": [
+            {
+              "code": "ContactPoint"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom",
+          "max": "*",
+          "definition": "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted."
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.telecom.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.telecom.extension"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.system",
+            "max": "1"
+          },
+          "definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.3"
+            },
+            {
+              "identity": "rim",
+              "map": "./scheme"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointType"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "phone | fax | email | pager | other",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that FHIR strings may not exceed 1MB in size",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-system",
+            "description": "Telecommunications form for contact point",
+            "strength": "required"
+          },
+          "condition": [
+            "cpt-2",
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "path": "Patient.telecom.system"
+        },
+        {
+          "requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.value",
+            "max": "1"
+          },
+          "definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
+          "short": "The actual contact point details",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.1 (or XTN.12)"
+            },
+            {
+              "identity": "rim",
+              "map": "./url"
+            },
+            {
+              "identity": "servd",
+              "map": "./Value"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom.value",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.2 - but often indicated by field"
+            },
+            {
+              "identity": "rim",
+              "map": "unique(./use)"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointPurpose"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "fixedCode": "home",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.use",
+            "max": "1"
+          },
+          "definition": "Identifies the purpose for the contact point.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-use",
+            "description": "Use of contact point",
+            "strength": "required"
+          },
+          "short": "home | work | temp | old | mobile - purpose of this contact point",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
+          "condition": [
+            "ele-1"
+          ],
+          "isModifier": true,
+          "isSummary": true,
+          "path": "Patient.telecom.use",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.rank",
+            "max": "1"
+          },
+          "definition": "Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values.",
+          "short": "Specify preferred order of use (1 = highest)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "positiveInt"
+            }
+          ],
+          "path": "Patient.telecom.rank"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.period",
+            "max": "1"
+          },
+          "definition": "Time period when the contact point was/is in use.",
+          "short": "Time period when the contact point was/is in use",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:start)) or not(exists(f:end)) or (f:start/@value <= f:end/@value)",
+              "key": "per-1",
+              "human": "If present, start SHALL have a lower value than end",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This is not a duration - that's a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. \"the patient was an inpatient of the hospital for this time range\") or one value from the range applies (e.g. \"give to the patient between these two times\"). If duration is required, specify the type as Interval|Duration.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "./useablePeriod[type=\"IVL<TS>\"]"
+            },
+            {
+              "identity": "servd",
+              "map": "./StartDate and ./EndDate"
+            },
+            {
+              "identity": "v2",
+              "map": "DR"
+            },
+            {
+              "identity": "rim",
+              "map": "IVL<TS>[lowClosed=\"true\" and highClosed=\"true\"] or URG<TS>[lowClosed=\"true\" and highClosed=\"true\"]"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "Period"
+            }
+          ],
+          "path": "Patient.telecom.period"
+        },
+        {
+          "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+          "base": {
+            "min": 0,
+            "path": "Patient.telecom",
+            "max": "*"
+          },
+          "sliceName": "phone/mobilePhone",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-13, PID-14, PID-40"
+            },
+            {
+              "identity": "rim",
+              "map": "telecom"
+            },
+            {
+              "identity": "cda",
+              "map": ".telecom"
+            },
+            {
+              "identity": "v2",
+              "map": "XTN"
+            },
+            {
+              "identity": "rim",
+              "map": "TEL"
+            },
+            {
+              "identity": "servd",
+              "map": "ContactPoint"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Phone numbers.",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:value)) or exists(f:system)",
+              "key": "cpt-2",
+              "human": "A system is required if a value is provided.",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).",
+          "type": [
+            {
+              "code": "ContactPoint"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom",
+          "max": "*",
+          "definition": "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted."
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.telecom.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.telecom.extension"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.system",
+            "max": "1"
+          },
+          "definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.3"
+            },
+            {
+              "identity": "rim",
+              "map": "./scheme"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointType"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "phone | fax | email | pager | other",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that FHIR strings may not exceed 1MB in size",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-system",
+            "description": "Telecommunications form for contact point",
+            "strength": "required"
+          },
+          "condition": [
+            "cpt-2",
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "path": "Patient.telecom.system"
+        },
+        {
+          "requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.value",
+            "max": "1"
+          },
+          "definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
+          "short": "The actual contact point details",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.1 (or XTN.12)"
+            },
+            {
+              "identity": "rim",
+              "map": "./url"
+            },
+            {
+              "identity": "servd",
+              "map": "./Value"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom.value",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.2 - but often indicated by field"
+            },
+            {
+              "identity": "rim",
+              "map": "unique(./use)"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointPurpose"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "fixedCode": "mobile",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.use",
+            "max": "1"
+          },
+          "definition": "Identifies the purpose for the contact point.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-use",
+            "description": "Use of contact point",
+            "strength": "required"
+          },
+          "short": "home | work | temp | old | mobile - purpose of this contact point",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
+          "condition": [
+            "ele-1"
+          ],
+          "isModifier": true,
+          "isSummary": true,
+          "path": "Patient.telecom.use",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.rank",
+            "max": "1"
+          },
+          "definition": "Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values.",
+          "short": "Specify preferred order of use (1 = highest)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "positiveInt"
+            }
+          ],
+          "path": "Patient.telecom.rank"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.period",
+            "max": "1"
+          },
+          "definition": "Time period when the contact point was/is in use.",
+          "short": "Time period when the contact point was/is in use",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:start)) or not(exists(f:end)) or (f:start/@value <= f:end/@value)",
+              "key": "per-1",
+              "human": "If present, start SHALL have a lower value than end",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This is not a duration - that's a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. \"the patient was an inpatient of the hospital for this time range\") or one value from the range applies (e.g. \"give to the patient between these two times\"). If duration is required, specify the type as Interval|Duration.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "./useablePeriod[type=\"IVL<TS>\"]"
+            },
+            {
+              "identity": "servd",
+              "map": "./StartDate and ./EndDate"
+            },
+            {
+              "identity": "v2",
+              "map": "DR"
+            },
+            {
+              "identity": "rim",
+              "map": "IVL<TS>[lowClosed=\"true\" and highClosed=\"true\"] or URG<TS>[lowClosed=\"true\" and highClosed=\"true\"]"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "Period"
+            }
+          ],
+          "path": "Patient.telecom.period"
+        },
+        {
+          "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+          "slicing": {
+            "rules": "open",
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "use"
+              }
+            ]
+          },
+          "base": {
+            "min": 0,
+            "path": "Patient.telecom",
+            "max": "*"
+          },
+          "definition": "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-13, PID-14, PID-40"
+            },
+            {
+              "identity": "rim",
+              "map": "telecom"
+            },
+            {
+              "identity": "cda",
+              "map": ".telecom"
+            },
+            {
+              "identity": "v2",
+              "map": "XTN"
+            },
+            {
+              "identity": "rim",
+              "map": "TEL"
+            },
+            {
+              "identity": "servd",
+              "map": "ContactPoint"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "A contact detail for the individual",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:value)) or exists(f:system)",
+              "key": "cpt-2",
+              "human": "A system is required if a value is provided.",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).",
+          "type": [
+            {
+              "code": "ContactPoint"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom",
+          "max": "*",
+          "sliceName": "email"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.telecom.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.telecom.extension"
+        },
+        {
+          "fixedCode": "email",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.system",
+            "max": "1"
+          },
+          "definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.3"
+            },
+            {
+              "identity": "rim",
+              "map": "./scheme"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointType"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "phone | fax | email | pager | other",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "Note that FHIR strings may not exceed 1MB in size",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-system",
+            "description": "Telecommunications form for contact point",
+            "strength": "required"
+          },
+          "condition": [
+            "cpt-2",
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "path": "Patient.telecom.system"
+        },
+        {
+          "requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.value",
+            "max": "1"
+          },
+          "definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
+          "short": "The actual contact point details",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.1 (or XTN.12)"
+            },
+            {
+              "identity": "rim",
+              "map": "./url"
+            },
+            {
+              "identity": "servd",
+              "map": "./Value"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom.value",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.2 - but often indicated by field"
+            },
+            {
+              "identity": "rim",
+              "map": "unique(./use)"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointPurpose"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.use",
+            "max": "1"
+          },
+          "definition": "Identifies the purpose for the contact point.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-use",
+            "description": "Use of contact point",
+            "strength": "required"
+          },
+          "short": "home | work | temp | old | mobile - purpose of this contact point",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
+          "condition": [
+            "ele-1"
+          ],
+          "isModifier": true,
+          "isSummary": true,
+          "path": "Patient.telecom.use",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.rank",
+            "max": "1"
+          },
+          "definition": "Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values.",
+          "short": "Specify preferred order of use (1 = highest)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "positiveInt"
+            }
+          ],
+          "path": "Patient.telecom.rank"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.period",
+            "max": "1"
+          },
+          "definition": "Time period when the contact point was/is in use.",
+          "short": "Time period when the contact point was/is in use",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:start)) or not(exists(f:end)) or (f:start/@value <= f:end/@value)",
+              "key": "per-1",
+              "human": "If present, start SHALL have a lower value than end",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This is not a duration - that's a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. \"the patient was an inpatient of the hospital for this time range\") or one value from the range applies (e.g. \"give to the patient between these two times\"). If duration is required, specify the type as Interval|Duration.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "./useablePeriod[type=\"IVL<TS>\"]"
+            },
+            {
+              "identity": "servd",
+              "map": "./StartDate and ./EndDate"
+            },
+            {
+              "identity": "v2",
+              "map": "DR"
+            },
+            {
+              "identity": "rim",
+              "map": "IVL<TS>[lowClosed=\"true\" and highClosed=\"true\"] or URG<TS>[lowClosed=\"true\" and highClosed=\"true\"]"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "Period"
+            }
+          ],
+          "path": "Patient.telecom.period"
+        },
+        {
+          "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+          "base": {
+            "min": 0,
+            "path": "Patient.telecom",
+            "max": "*"
+          },
+          "sliceName": "email/workEmail",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-13, PID-14, PID-40"
+            },
+            {
+              "identity": "rim",
+              "map": "telecom"
+            },
+            {
+              "identity": "cda",
+              "map": ".telecom"
+            },
+            {
+              "identity": "v2",
+              "map": "XTN"
+            },
+            {
+              "identity": "rim",
+              "map": "TEL"
+            },
+            {
+              "identity": "servd",
+              "map": "ContactPoint"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "A contact detail for the individual",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:value)) or exists(f:system)",
+              "key": "cpt-2",
+              "human": "A system is required if a value is provided.",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).",
+          "type": [
+            {
+              "code": "ContactPoint"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom",
+          "max": "*",
+          "definition": "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted."
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.telecom.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.telecom.extension"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.system",
+            "max": "1"
+          },
+          "definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.3"
+            },
+            {
+              "identity": "rim",
+              "map": "./scheme"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointType"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "phone | fax | email | pager | other",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that FHIR strings may not exceed 1MB in size",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-system",
+            "description": "Telecommunications form for contact point",
+            "strength": "required"
+          },
+          "condition": [
+            "cpt-2",
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "path": "Patient.telecom.system"
+        },
+        {
+          "requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.value",
+            "max": "1"
+          },
+          "definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
+          "short": "The actual contact point details",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.1 (or XTN.12)"
+            },
+            {
+              "identity": "rim",
+              "map": "./url"
+            },
+            {
+              "identity": "servd",
+              "map": "./Value"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom.value",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.2 - but often indicated by field"
+            },
+            {
+              "identity": "rim",
+              "map": "unique(./use)"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointPurpose"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "fixedCode": "work",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.use",
+            "max": "1"
+          },
+          "definition": "Identifies the purpose for the contact point.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-use",
+            "description": "Use of contact point",
+            "strength": "required"
+          },
+          "short": "home | work | temp | old | mobile - purpose of this contact point",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
+          "condition": [
+            "ele-1"
+          ],
+          "isModifier": true,
+          "isSummary": true,
+          "path": "Patient.telecom.use",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.rank",
+            "max": "1"
+          },
+          "definition": "Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values.",
+          "short": "Specify preferred order of use (1 = highest)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "positiveInt"
+            }
+          ],
+          "path": "Patient.telecom.rank"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.period",
+            "max": "1"
+          },
+          "definition": "Time period when the contact point was/is in use.",
+          "short": "Time period when the contact point was/is in use",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:start)) or not(exists(f:end)) or (f:start/@value <= f:end/@value)",
+              "key": "per-1",
+              "human": "If present, start SHALL have a lower value than end",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This is not a duration - that's a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. \"the patient was an inpatient of the hospital for this time range\") or one value from the range applies (e.g. \"give to the patient between these two times\"). If duration is required, specify the type as Interval|Duration.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "./useablePeriod[type=\"IVL<TS>\"]"
+            },
+            {
+              "identity": "servd",
+              "map": "./StartDate and ./EndDate"
+            },
+            {
+              "identity": "v2",
+              "map": "DR"
+            },
+            {
+              "identity": "rim",
+              "map": "IVL<TS>[lowClosed=\"true\" and highClosed=\"true\"] or URG<TS>[lowClosed=\"true\" and highClosed=\"true\"]"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "Period"
+            }
+          ],
+          "path": "Patient.telecom.period"
+        },
+        {
+          "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+          "base": {
+            "min": 0,
+            "path": "Patient.telecom",
+            "max": "*"
+          },
+          "sliceName": "email/homeEmail",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-13, PID-14, PID-40"
+            },
+            {
+              "identity": "rim",
+              "map": "telecom"
+            },
+            {
+              "identity": "cda",
+              "map": ".telecom"
+            },
+            {
+              "identity": "v2",
+              "map": "XTN"
+            },
+            {
+              "identity": "rim",
+              "map": "TEL"
+            },
+            {
+              "identity": "servd",
+              "map": "ContactPoint"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "A contact detail for the individual",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:value)) or exists(f:system)",
+              "key": "cpt-2",
+              "human": "A system is required if a value is provided.",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).",
+          "type": [
+            {
+              "code": "ContactPoint"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom",
+          "max": "*",
+          "definition": "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted."
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.telecom.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.telecom.extension"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.system",
+            "max": "1"
+          },
+          "definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.3"
+            },
+            {
+              "identity": "rim",
+              "map": "./scheme"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointType"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "phone | fax | email | pager | other",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that FHIR strings may not exceed 1MB in size",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-system",
+            "description": "Telecommunications form for contact point",
+            "strength": "required"
+          },
+          "condition": [
+            "cpt-2",
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "path": "Patient.telecom.system"
+        },
+        {
+          "requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.value",
+            "max": "1"
+          },
+          "definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
+          "short": "The actual contact point details",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.1 (or XTN.12)"
+            },
+            {
+              "identity": "rim",
+              "map": "./url"
+            },
+            {
+              "identity": "servd",
+              "map": "./Value"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom.value",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.2 - but often indicated by field"
+            },
+            {
+              "identity": "rim",
+              "map": "unique(./use)"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointPurpose"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "fixedCode": "home",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.use",
+            "max": "1"
+          },
+          "definition": "Identifies the purpose for the contact point.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-use",
+            "description": "Use of contact point",
+            "strength": "required"
+          },
+          "short": "home | work | temp | old | mobile - purpose of this contact point",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
+          "condition": [
+            "ele-1"
+          ],
+          "isModifier": true,
+          "isSummary": true,
+          "path": "Patient.telecom.use",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.rank",
+            "max": "1"
+          },
+          "definition": "Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values.",
+          "short": "Specify preferred order of use (1 = highest)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "positiveInt"
+            }
+          ],
+          "path": "Patient.telecom.rank"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.period",
+            "max": "1"
+          },
+          "definition": "Time period when the contact point was/is in use.",
+          "short": "Time period when the contact point was/is in use",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:start)) or not(exists(f:end)) or (f:start/@value <= f:end/@value)",
+              "key": "per-1",
+              "human": "If present, start SHALL have a lower value than end",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This is not a duration - that's a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. \"the patient was an inpatient of the hospital for this time range\") or one value from the range applies (e.g. \"give to the patient between these two times\"). If duration is required, specify the type as Interval|Duration.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "./useablePeriod[type=\"IVL<TS>\"]"
+            },
+            {
+              "identity": "servd",
+              "map": "./StartDate and ./EndDate"
+            },
+            {
+              "identity": "v2",
+              "map": "DR"
+            },
+            {
+              "identity": "rim",
+              "map": "IVL<TS>[lowClosed=\"true\" and highClosed=\"true\"] or URG<TS>[lowClosed=\"true\" and highClosed=\"true\"]"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "Period"
+            }
+          ],
+          "path": "Patient.telecom.period"
+        },
+        {
+          "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+          "base": {
+            "min": 0,
+            "path": "Patient.telecom",
+            "max": "*"
+          },
+          "sliceName": "pager",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-13, PID-14, PID-40"
+            },
+            {
+              "identity": "rim",
+              "map": "telecom"
+            },
+            {
+              "identity": "cda",
+              "map": ".telecom"
+            },
+            {
+              "identity": "v2",
+              "map": "XTN"
+            },
+            {
+              "identity": "rim",
+              "map": "TEL"
+            },
+            {
+              "identity": "servd",
+              "map": "ContactPoint"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "A contact detail for the individual",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:value)) or exists(f:system)",
+              "key": "cpt-2",
+              "human": "A system is required if a value is provided.",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address may not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).",
+          "type": [
+            {
+              "code": "ContactPoint"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom",
+          "max": "*",
+          "definition": "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted."
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.telecom.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.telecom.extension"
+        },
+        {
+          "fixedCode": "pager",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.system",
+            "max": "1"
+          },
+          "definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.3"
+            },
+            {
+              "identity": "rim",
+              "map": "./scheme"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointType"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "phone | fax | email | pager | other",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "Note that FHIR strings may not exceed 1MB in size",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-system",
+            "description": "Telecommunications form for contact point",
+            "strength": "required"
+          },
+          "condition": [
+            "cpt-2",
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "path": "Patient.telecom.system"
+        },
+        {
+          "requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.value",
+            "max": "1"
+          },
+          "definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
+          "short": "The actual contact point details",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.1 (or XTN.12)"
+            },
+            {
+              "identity": "rim",
+              "map": "./url"
+            },
+            {
+              "identity": "servd",
+              "map": "./Value"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.telecom.value",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "XTN.2 - but often indicated by field"
+            },
+            {
+              "identity": "rim",
+              "map": "unique(./use)"
+            },
+            {
+              "identity": "servd",
+              "map": "./ContactPointPurpose"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.use",
+            "max": "1"
+          },
+          "definition": "Identifies the purpose for the contact point.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/contact-point-use",
+            "description": "Use of contact point",
+            "strength": "required"
+          },
+          "short": "home | work | temp | old | mobile - purpose of this contact point",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one. Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
+          "condition": [
+            "ele-1"
+          ],
+          "isModifier": true,
+          "isSummary": true,
+          "path": "Patient.telecom.use",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.rank",
+            "max": "1"
+          },
+          "definition": "Specifies a preferred order in which to use a set of contacts. Contacts are ranked with lower values coming before higher values.",
+          "short": "Specify preferred order of use (1 = highest)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "positiveInt"
+            }
+          ],
+          "path": "Patient.telecom.rank"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "ContactPoint.period",
+            "max": "1"
+          },
+          "definition": "Time period when the contact point was/is in use.",
+          "short": "Time period when the contact point was/is in use",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:start)) or not(exists(f:end)) or (f:start/@value <= f:end/@value)",
+              "key": "per-1",
+              "human": "If present, start SHALL have a lower value than end",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This is not a duration - that's a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. \"the patient was an inpatient of the hospital for this time range\") or one value from the range applies (e.g. \"give to the patient between these two times\"). If duration is required, specify the type as Interval|Duration.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "./useablePeriod[type=\"IVL<TS>\"]"
+            },
+            {
+              "identity": "servd",
+              "map": "./StartDate and ./EndDate"
+            },
+            {
+              "identity": "v2",
+              "map": "DR"
+            },
+            {
+              "identity": "rim",
+              "map": "IVL<TS>[lowClosed=\"true\" and highClosed=\"true\"] or URG<TS>[lowClosed=\"true\" and highClosed=\"true\"]"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "Period"
+            }
+          ],
+          "path": "Patient.telecom.period"
+        },
+        {
+          "requirements": "Needed for identification of the individual, in combination with (at least) name and birth date. Gender of individual drives many clinical processes.",
+          "base": {
+            "min": 0,
+            "path": "Patient.gender",
+            "max": "1"
+          },
+          "definition": "Administrative Gender - the gender that the patient is considered to have for administration and record keeping purposes.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-8"
+            },
+            {
+              "identity": "rim",
+              "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
+            },
+            {
+              "identity": "cda",
+              "map": ".patient.administrativeGenderCode"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "male | female | other | unknown",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "The gender may not match the biological sex as determined by genetics, or the individual's preferred identification. Note that for both humans and particularly animals, there are other legitimate possibilities than M and F, though the vast majority of systems and contexts only support M and F.  Systems providing decision support or enforcing business rules should ideally do this on the basis of Observations dealing with the specific gender aspect of interest (anatomical, chromosonal, social, etc.)  However, because these observations are infrequently recorded, defaulting to the administrative gender is common practice.  Where such defaulting occurs, rule enforcement should allow for the variation between administrative and biological, chromosonal and other gender aspects.  For example, an alert about a hysterectomy on a male should be handled as a warning or overrideable error, not a \"hard\" error.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/administrative-gender",
+            "description": "The gender of a person used for administrative purposes.",
+            "strength": "required"
+          },
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.gender",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "Age of the individual drives many clinical processes.",
+          "base": {
+            "min": 0,
+            "path": "Patient.birthDate",
+            "max": "1"
+          },
+          "definition": "The date of birth for the individual.",
+          "short": "The date of birth for the individual",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "At least an estimated year should be provided as a guess if the real DOB is unknown  There is a standard extension \"patient-birthTime\" available that should be used where Time is required (such as in maternaty/infant care systems).",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-7"
+            },
+            {
+              "identity": "rim",
+              "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/birthTime"
+            },
+            {
+              "identity": "cda",
+              "map": ".patient.birthTime"
+            },
+            {
+              "identity": "loinc",
+              "map": "21112-8"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.birthDate",
+          "type": [
+            {
+              "code": "date"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive.",
+          "base": {
+            "min": 0,
+            "path": "Patient.deceased[x]",
+            "max": "1"
+          },
+          "definition": "Indicates if the individual is deceased or not.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-30  (bool) and PID-29 (datetime)"
+            },
+            {
+              "identity": "rim",
+              "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Indicates if the individual is deceased or not",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "If there's no value in the instance it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive.",
+          "condition": [
+            "ele-1"
+          ],
+          "isModifier": true,
+          "isSummary": true,
+          "path": "Patient.deceased[x]",
+          "type": [
+            {
+              "code": "boolean"
+            },
+            {
+              "code": "dateTime"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "May need to keep track of patient addresses for contacting, billing or reporting requirements and also to help with identification.",
+          "base": {
+            "min": 0,
+            "path": "Patient.address",
+            "max": "*"
+          },
+          "definition": "Addresses for the individual.",
+          "short": "Addresses for the individual",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Patient may have multiple addresses with different uses or applicable periods.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-11"
+            },
+            {
+              "identity": "rim",
+              "map": "addr"
+            },
+            {
+              "identity": "cda",
+              "map": ".addr"
+            },
+            {
+              "identity": "v2",
+              "map": "XAD"
+            },
+            {
+              "identity": "rim",
+              "map": "AD"
+            },
+            {
+              "identity": "servd",
+              "map": "Address"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.address",
+          "type": [
+            {
+              "code": "Address"
+            }
+          ],
+          "max": "*"
+        },
+        {
+          "requirements": "Most, if not all systems capture it.",
+          "base": {
+            "min": 0,
+            "path": "Patient.maritalStatus",
+            "max": "1"
+          },
+          "definition": "This field contains a patient's most recent marital (civil) status.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-16"
+            },
+            {
+              "identity": "rim",
+              "map": "player[classCode=PSN]/maritalStatusCode"
+            },
+            {
+              "identity": "cda",
+              "map": ".patient.maritalStatusCode"
+            },
+            {
+              "identity": "v2",
+              "map": "CE/CNE/CWE"
+            },
+            {
+              "identity": "rim",
+              "map": "CD"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:CodeableConcept rdfs:subClassOf dt:CD"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Marital (civil) status of a patient",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/marital-status",
+            "description": "The domestic partnership status of a person.",
+            "strength": "required"
+          },
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.maritalStatus",
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "For disambiguation of multiple-birth children, especially relevant where the care provider doesn't meet the patient, such as labs.",
+          "base": {
+            "min": 0,
+            "path": "Patient.multipleBirth[x]",
+            "max": "1"
+          },
+          "definition": "Indicates whether the patient is part of a multiple or indicates the actual birth order.",
+          "short": "Whether patient is part of a multiple birth",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Where the valueInteger is provided, the number is the birth number in the sequence.\r\n      E.g. The middle birth in tripplets would be valueInteger=2 and the third born would have valueInteger=3\r\n      If a bool value was provided for this tripplets examle, then all 3 patient records would have valueBool=true (the ordering is not indicated).",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-24 (bool), PID-25 (integer)"
+            },
+            {
+              "identity": "rim",
+              "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthInd,  player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthOrderNumber"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "path": "Patient.multipleBirth[x]",
+          "type": [
+            {
+              "code": "boolean"
+            },
+            {
+              "code": "integer"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "Many EHR systems have the capability to capture an image of the patient. Fits with newer social media usage too.",
+          "base": {
+            "min": 0,
+            "path": "Patient.photo",
+            "max": "*"
+          },
+          "definition": "Image of the patient.",
+          "short": "Image of the patient",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:data)) or exists(f:contentType)",
+              "key": "att-1",
+              "human": "It the Attachment has data, it SHALL have a contentType",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "When providing a summary view (for example with Observation.value[x]) Attachment should be represented with a brief display text such as \"Attachment\".",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "OBX-5 - needs a profile"
+            },
+            {
+              "identity": "rim",
+              "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/desc"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "v2",
+              "map": "ED/RP"
+            },
+            {
+              "identity": "rim",
+              "map": "ED"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.photo",
+          "type": [
+            {
+              "code": "Attachment"
+            }
+          ],
+          "max": "*"
+        },
+        {
+          "requirements": "Need to track people you can contact about the patient.",
+          "base": {
+            "min": 0,
+            "path": "Patient.contact",
+            "max": "*"
+          },
+          "definition": "A contact party (e.g. guardian, partner, friend) for the patient.",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
+              "valueString": "Contact"
+            }
+          ],
+          "short": "A contact party (e.g. guardian, partner, friend) for the patient",
+          "constraint": [
+            {
+              "xpath": "f:name or f:telecom or f:address or f:organization",
+              "key": "pat-1",
+              "human": "SHALL at least contain a contact's details or a reference to an organization",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Contact covers all kinds of contact parties: family members, business contacts, guardians, caregivers. Not applicable to register pedigree and family ties beyond use of having contact.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/scopedRole[classCode=CON]"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "path": "Patient.contact",
+          "type": [
+            {
+              "code": "BackboneElement"
+            }
+          ],
+          "max": "*"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.contact.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.contact.extension"
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content",
+            "modifiers"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Extensions that cannot be ignored",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "isModifier": true,
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "BackboneElement.modifierExtension",
+            "max": "*"
+          },
+          "path": "Patient.contact.modifierExtension"
+        },
+        {
+          "requirements": "Used to determine which contact person is the most relevant to approach, depending on circumstances.",
+          "base": {
+            "min": 0,
+            "path": "Patient.contact.relationship",
+            "max": "*"
+          },
+          "definition": "The nature of the relationship between the patient and the contact person.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "NK1-7, NK1-3"
+            },
+            {
+              "identity": "rim",
+              "map": "code"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "v2",
+              "map": "CE/CNE/CWE"
+            },
+            {
+              "identity": "rim",
+              "map": "CD"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:CodeableConcept rdfs:subClassOf dt:CD"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "The kind of relationship",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/patient-contact-relationship",
+            "description": "The nature of the relationship between a patient and a contact person for that patient.",
+            "strength": "extensible"
+          },
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.contact.relationship",
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "max": "*"
+        },
+        {
+          "requirements": "Contact persons need to be identified by name, but it is uncommon to need details about multiple other names for that contact person.",
+          "base": {
+            "min": 0,
+            "path": "Patient.contact.name",
+            "max": "1"
+          },
+          "definition": "A name associated with the contact person.",
+          "short": "A name associated with the contact person",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Names may be changed, or repudiated, or people may have different names in different contexts. Names may be divided into parts of different type that have variable significance depending on context, though the division into parts does not always matter. With personal names, the different parts may or may not be imbued with some implicit meaning; various cultures associate different importance with the name parts and the degree to which systems must care about name parts around the world varies widely.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "NK1-2"
+            },
+            {
+              "identity": "rim",
+              "map": "name"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "v2",
+              "map": "XPN"
+            },
+            {
+              "identity": "rim",
+              "map": "EN (actually, PN)"
+            },
+            {
+              "identity": "servd",
+              "map": "ProviderName"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.contact.name",
+          "type": [
+            {
+              "code": "HumanName"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+          "base": {
+            "min": 0,
+            "path": "Patient.contact.telecom",
+            "max": "*"
+          },
+          "definition": "A contact detail for the person, e.g. a telephone number or an email address.",
+          "short": "A contact detail for the person",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:value)) or exists(f:system)",
+              "key": "cpt-2",
+              "human": "A system is required if a value is provided.",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Contact may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently, and also to help with identification.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "NK1-5, NK1-6, NK1-40"
+            },
+            {
+              "identity": "rim",
+              "map": "telecom"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "v2",
+              "map": "XTN"
+            },
+            {
+              "identity": "rim",
+              "map": "TEL"
+            },
+            {
+              "identity": "servd",
+              "map": "ContactPoint"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.contact.telecom",
+          "type": [
+            {
+              "code": "ContactPoint"
+            }
+          ],
+          "max": "*"
+        },
+        {
+          "requirements": "Need to keep track where the contact person can be contacted per postal mail or visited.",
+          "base": {
+            "min": 0,
+            "path": "Patient.contact.address",
+            "max": "1"
+          },
+          "definition": "Address for the contact person.",
+          "short": "Address for the contact person",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note: address is for postal addresses, not physical locations.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "NK1-4"
+            },
+            {
+              "identity": "rim",
+              "map": "addr"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "v2",
+              "map": "XAD"
+            },
+            {
+              "identity": "rim",
+              "map": "AD"
+            },
+            {
+              "identity": "servd",
+              "map": "Address"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.contact.address",
+          "type": [
+            {
+              "code": "Address"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "Needed to address the person correctly.",
+          "base": {
+            "min": 0,
+            "path": "Patient.contact.gender",
+            "max": "1"
+          },
+          "definition": "Administrative Gender - the gender that the contact person is considered to have for administration and record keeping purposes.",
+          "short": "male | female | other | unknown",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Note that FHIR strings may not exceed 1MB in size",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "NK1-15"
+            },
+            {
+              "identity": "rim",
+              "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/administrative-gender",
+            "description": "The gender of a person used for administrative purposes.",
+            "strength": "required"
+          },
+          "condition": [
+            "ele-1"
+          ],
+          "path": "Patient.contact.gender",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "For guardians or business related contacts, the organization is relevant.",
+          "base": {
+            "min": 0,
+            "path": "Patient.contact.organization",
+            "max": "1"
+          },
+          "definition": "Organization on behalf of which the contact is acting or for which the contact is working.",
+          "short": "Organization that is associated with the contact",
+          "constraint": [
+            {
+              "xpath": "not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])",
+              "key": "ref-1",
+              "human": "SHALL have a local reference if the resource is provided inline",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "NK1-13, NK1-30, NK1-31, NK1-32, NK1-41"
+            },
+            {
+              "identity": "rim",
+              "map": "scoper"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "The target of a resource reference is a RIM entry point (Act, Role, or Entity)"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "pat-1",
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.contact.organization",
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": "http://hl7.org/fhir/StructureDefinition/Organization"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Patient.contact.period",
+            "max": "1"
+          },
+          "definition": "The period during which this contact person or organization is valid to be contacted relating to this patient.",
+          "short": "The period during which this contact person or organization is valid to be contacted relating to this patient",
+          "constraint": [
+            {
+              "xpath": "not(exists(f:start)) or not(exists(f:end)) or (f:start/@value <= f:end/@value)",
+              "key": "per-1",
+              "human": "If present, start SHALL have a lower value than end",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This is not a duration - that's a measure of time (a separate type), but a duration that occurs at a fixed value of time. A Period specifies a range of time; the context of use will specify whether the entire range applies (e.g. \"the patient was an inpatient of the hospital for this time range\") or one value from the range applies (e.g. \"give to the patient between these two times\"). If duration is required, specify the type as Interval|Duration.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "effectiveTime"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "v2",
+              "map": "DR"
+            },
+            {
+              "identity": "rim",
+              "map": "IVL<TS>[lowClosed=\"true\" and highClosed=\"true\"] or URG<TS>[lowClosed=\"true\" and highClosed=\"true\"]"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "Period"
+            }
+          ],
+          "path": "Patient.contact.period"
+        },
+        {
+          "requirements": "Many clinical systems are extended to care for animal patients as well as human.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "player[classCode=ANM]"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "base": {
+            "min": 0,
+            "path": "Patient.animal",
+            "max": "1"
+          },
+          "definition": "This patient is known to be an animal.",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
+              "valueString": "Animal"
+            }
+          ],
+          "short": "This patient is known to be an animal (non-human)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "The animal element is labeled \"Is Modifier\" since patients may be non-human. Systems SHALL either handle patient details appropriately (e.g. inform users patient is not human) or reject declared animal records.   The absense of the animal element does not imply that the patient is a human. If a system requires such a positive assertion that the patient is human, an extension will be required.  (Do not use a species of homo-sapiens in animal species, as this would incorrectly infer that the patient is an animal).",
+          "condition": [
+            "ele-1"
+          ],
+          "isModifier": true,
+          "isSummary": true,
+          "path": "Patient.animal",
+          "type": [
+            {
+              "code": "BackboneElement"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.animal.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.animal.extension"
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content",
+            "modifiers"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Extensions that cannot be ignored",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "isModifier": true,
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "BackboneElement.modifierExtension",
+            "max": "*"
+          },
+          "path": "Patient.animal.modifierExtension"
+        },
+        {
+          "requirements": "Need to know what kind of animal.",
+          "base": {
+            "min": 1,
+            "path": "Patient.animal.species",
+            "max": "1"
+          },
+          "definition": "Identifies the high level taxonomic categorization of the kind of animal.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-35"
+            },
+            {
+              "identity": "rim",
+              "map": "code"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "v2",
+              "map": "CE/CNE/CWE"
+            },
+            {
+              "identity": "rim",
+              "map": "CD"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:CodeableConcept rdfs:subClassOf dt:CD"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "E.g. Dog, Cow",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "If the patient is non-human, at least a species SHALL be specified. Species SHALL be a widely recognised taxonomic classification.  It may or may not be Linnaean taxonomy and may or may not be at the level of species. If the level is finer than species--such as a breed code--the code system used SHALL allow inference of the species.  (The common example is that the word \"Hereford\" does not allow inference of the species Bos taurus, because there is a Hereford pig breed, but the SNOMED CT code for \"Hereford Cattle Breed\" does.).",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/animal-species",
+            "description": "The species of an animal.",
+            "strength": "example"
+          },
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.animal.species",
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "May need to know the specific kind within the species.",
+          "base": {
+            "min": 0,
+            "path": "Patient.animal.breed",
+            "max": "1"
+          },
+          "definition": "Identifies the detailed categorization of the kind of animal.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-37"
+            },
+            {
+              "identity": "rim",
+              "map": "playedRole[classCode=GEN]/scoper[classCode=ANM, determinerCode=KIND]/code"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "v2",
+              "map": "CE/CNE/CWE"
+            },
+            {
+              "identity": "rim",
+              "map": "CD"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:CodeableConcept rdfs:subClassOf dt:CD"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "E.g. Poodle, Angus",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Breed MAY be used to provide further taxonomic or non-taxonomic classification.  It may involve local or proprietary designation--such as commercial strain--and/or additional information such as production type.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/animal-breeds",
+            "description": "The breed of an animal.",
+            "strength": "example"
+          },
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.animal.breed",
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "Gender status can affect housing and animal behavior.",
+          "base": {
+            "min": 0,
+            "path": "Patient.animal.genderStatus",
+            "max": "1"
+          },
+          "definition": "Indicates the current state of the animal's reproductive organs.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "genderStatusCode"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "v2",
+              "map": "CE/CNE/CWE"
+            },
+            {
+              "identity": "rim",
+              "map": "CD"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:CodeableConcept rdfs:subClassOf dt:CD"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "E.g. Neutered, Intact",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination.",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/animal-genderstatus",
+            "description": "The state of the animal's reproductive organs.",
+            "strength": "example"
+          },
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.animal.genderStatus",
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "If a patient does not speak the local language, interpreters may be required, so languages spoken and proficiency is an important things to keep track of both for patient and other persons of interest.",
+          "base": {
+            "min": 0,
+            "path": "Patient.communication",
+            "max": "*"
+          },
+          "definition": "Languages which may be used to communicate with the patient about his or her health.",
+          "short": "A list of Languages which may be used to communicate with the patient about his or her health",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "If no language is specified, this *implies* that the default local language is spoken.  If you need to convey proficiency for multiple modes then you need multiple Patient.Communication associations.   For animals, language is not a relevant field, and should be absent from the instance. If the Patient does not speak the default local language, then the Interpreter Required Standard can be used to explicitly declare that an interpreter is required.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "LanguageCommunication"
+            },
+            {
+              "identity": "cda",
+              "map": "patient.languageCommunication"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "path": "Patient.communication",
+          "type": [
+            {
+              "code": "BackboneElement"
+            }
+          ],
+          "max": "*"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.communication.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.communication.extension"
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content",
+            "modifiers"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Extensions that cannot be ignored",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "isModifier": true,
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "BackboneElement.modifierExtension",
+            "max": "*"
+          },
+          "path": "Patient.communication.modifierExtension"
+        },
+        {
+          "requirements": "Most systems in multilingual countries will want to convey language. Not all systems actually need the regional dialect.",
+          "base": {
+            "min": 1,
+            "path": "Patient.communication.language",
+            "max": "1"
+          },
+          "definition": "The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. \"en\" for English, or \"en-US\" for American English versus \"en-EN\" for England English.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-15, LAN-2"
+            },
+            {
+              "identity": "rim",
+              "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/languageCommunication/code"
+            },
+            {
+              "identity": "cda",
+              "map": ".languageCode"
+            },
+            {
+              "identity": "v2",
+              "map": "CE/CNE/CWE"
+            },
+            {
+              "identity": "rim",
+              "map": "CD"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:CodeableConcept rdfs:subClassOf dt:CD"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "The language which can be used to communicate with the patient about his or her health",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.",
+          "binding": {
+            "valueSetUri": "http://tools.ietf.org/html/bcp47",
+            "description": "A human language.",
+            "strength": "required"
+          },
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.communication.language",
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "People that master multiple languages up to certain level may prefer one or more, i.e. feel more confident in communicating in a particular language making other languages sort of a fall back method.",
+          "base": {
+            "min": 0,
+            "path": "Patient.communication.preferred",
+            "max": "1"
+          },
+          "definition": "Indicates whether or not the patient prefers this language (over other languages he masters up a certain level).",
+          "short": "Language preference indicator",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This language is specifically identified for communicating healthcare information.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-15"
+            },
+            {
+              "identity": "rim",
+              "map": "preferenceInd"
+            },
+            {
+              "identity": "cda",
+              "map": ".preferenceInd"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "path": "Patient.communication.preferred",
+          "type": [
+            {
+              "code": "boolean"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Patient.careProvider",
+            "max": "*"
+          },
+          "definition": "Patient's nominated care provider.",
+          "short": "Patient's nominated primary care provider",
+          "constraint": [
+            {
+              "xpath": "not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])",
+              "key": "ref-1",
+              "human": "SHALL have a local reference if the resource is provided inline",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disablity setting, or even organization that will provide people to perform the care provider roles.\r\n      This is not to be used to record Care Teams, these should be recorded on either the CarePlan or EpisodeOfCare resources.",
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PD1-4"
+            },
+            {
+              "identity": "rim",
+              "map": "subjectOf.CareEvent.performer.AssignedEntity"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "The target of a resource reference is a RIM entry point (Act, Role, or Entity)"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "*",
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": "http://hl7.org/fhir/StructureDefinition/Organization"
+            },
+            {
+              "code": "Reference",
+              "targetProfile": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+            }
+          ],
+          "path": "Patient.careProvider"
+        },
+        {
+          "requirements": "Need to know who recognizes this patient record, manages and updates it.",
+          "base": {
+            "min": 0,
+            "path": "Patient.managingOrganization",
+            "max": "1"
+          },
+          "definition": "Organization that is the custodian of the patient record.",
+          "short": "Organization that is the custodian of the patient record",
+          "constraint": [
+            {
+              "xpath": "not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])",
+              "key": "ref-1",
+              "human": "SHALL have a local reference if the resource is provided inline",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There is only one managing organization for a specific patient record. Other organizations will have their own Patient record, and may use the Link property to join the records together (or a Person resource which can include confidence ratings for the association).",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "scoper"
+            },
+            {
+              "identity": "cda",
+              "map": ".providerOrganization"
+            },
+            {
+              "identity": "rim",
+              "map": "The target of a resource reference is a RIM entry point (Act, Role, or Entity)"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "path": "Patient.managingOrganization",
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": "http://hl7.org/fhir/StructureDefinition/Organization"
+            }
+          ],
+          "max": "1"
+        },
+        {
+          "requirements": "There are multiple usecases: \r\n      * Duplicate patient records due to the clerical errors associated with the difficulties of identifying humans consistently, and * Distribution of patient information across multiple server",
+          "base": {
+            "min": 0,
+            "path": "Patient.link",
+            "max": "*"
+          },
+          "definition": "Link to another patient resource that concerns the same actual patient.",
+          "short": "Link to another patient resource that concerns the same actual person",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There is no assumption that linked patient records have mutual links.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "outboundLink"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "path": "Patient.link",
+          "type": [
+            {
+              "code": "BackboneElement"
+            }
+          ],
+          "max": "*"
+        },
+        {
+          "base": {
+            "min": 0,
+            "path": "Element.id",
+            "max": "1"
+          },
+          "definition": "unique id for the element within a resource (for internal references).",
+          "short": "xml:id (or equivalent in JSON)",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "RFC 4122",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "id"
+            }
+          ],
+          "path": "Patient.link.id",
+          "max": "1",
+          "representation": [
+            "xmlAttr"
+          ]
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "short": "Additional Content defined by implementations",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "Element.extension",
+            "max": "*"
+          },
+          "path": "Patient.link.extension"
+        },
+        {
+          "alias": [
+            "extensions",
+            "user content",
+            "modifiers"
+          ],
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element, and that modifies the understanding of the element that contains it. Usually modifier elements provide negation or qualification. In order to make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "Extensions that cannot be ignored",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 0,
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "isModifier": true,
+          "condition": [
+            "ele-1"
+          ],
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "max": "*",
+          "base": {
+            "min": 0,
+            "path": "BackboneElement.modifierExtension",
+            "max": "*"
+          },
+          "path": "Patient.link.modifierExtension"
+        },
+        {
+          "base": {
+            "min": 1,
+            "path": "Patient.link.other",
+            "max": "1"
+          },
+          "definition": "The other patient resource that the link refers to.",
+          "short": "The other patient resource that the link refers to",
+          "constraint": [
+            {
+              "xpath": "not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])",
+              "key": "ref-1",
+              "human": "SHALL have a local reference if the resource is provided inline",
+              "severity": "error"
+            },
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "isModifier": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "PID-3, MRG-1"
+            },
+            {
+              "identity": "rim",
+              "map": "id"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "The target of a resource reference is a RIM entry point (Act, Role, or Entity)"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "condition": [
+            "ele-1"
+          ],
+          "isSummary": true,
+          "max": "1",
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": "http://hl7.org/fhir/StructureDefinition/Patient"
+            }
+          ],
+          "path": "Patient.link.other"
+        },
+        {
+          "base": {
+            "min": 1,
+            "path": "Patient.link.type",
+            "max": "1"
+          },
+          "definition": "The type of link between this patient resource and another patient resource.",
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "typeCode"
+            },
+            {
+              "identity": "cda",
+              "map": "n/a"
+            },
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ],
+          "short": "replace | refer | seealso - type of link",
+          "constraint": [
+            {
+              "xpath": "@value|f:*|h:div",
+              "key": "ele-1",
+              "human": "All FHIR elements must have a @value or children",
+              "severity": "error"
+            }
+          ],
+          "min": 1,
+          "comment": "Note that FHIR strings may not exceed 1MB in size",
+          "binding": {
+            "valueSetUri": "http://hl7.org/fhir/ValueSet/link-type",
+            "description": "The type of link between this patient resource and another patient resource.",
+            "strength": "required"
+          },
+          "isModifier": true,
+          "condition": [
+            "ele-1"
+          ],
+          "max": "1",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "path": "Patient.link.type"
+        }
+      ]
+    },
+    "fhirVersion": "3.0.0",
+    "status": "draft",
+    "url": "http://example.com/fhir/SD/patient-telecom-reslice",
+    "kind": "resource",
+    "resourceType": "StructureDefinition",
+    "mapping": [
+      {
+        "identity": "rim",
+        "name": "RIM",
+        "uri": "http://hl7.org/v3"
+      },
+      {
+        "identity": "cda",
+        "name": "CDA (R2)",
+        "uri": "http://hl7.org/v3/cda"
+      },
+      {
+        "identity": "w5",
+        "name": "W5 Mapping",
+        "uri": "http://hl7.org/fhir/w5"
+      },
+      {
+        "identity": "v2",
+        "name": "HL7 v2",
+        "uri": "http://hl7.org/v2"
+      },
+      {
+        "identity": "loinc",
+        "name": "LOINC",
+        "uri": "http://loinc.org"
+      }
+    ],
+    "name": "patient-telecom-reslice"
+  }

--- a/test/fhirtypes/ElementDefinition.slicing.test.ts
+++ b/test/fhirtypes/ElementDefinition.slicing.test.ts
@@ -269,13 +269,13 @@ describe('ElementDefinition', () => {
       const quantity = valueX.addSlice('valueQuantity', { code: 'Quantity' });
       const integer = valueX.addSlice('valueInteger', { code: 'integer' });
       expect(quantity.id).toBe('Observation.value[x]:valueQuantity');
-      expect(quantity.path).toBe('Observation.valueQuantity');
+      expect(quantity.path).toBe('Observation.value[x]');
       expect(quantity.sliceName).toBe('valueQuantity');
       expect(quantity.min).toBe(0);
       expect(quantity.max).toBe('1');
       expect(quantity.type).toEqual([{ code: 'Quantity' }]);
       expect(integer.id).toBe('Observation.value[x]:valueInteger');
-      expect(integer.path).toBe('Observation.valueInteger');
+      expect(integer.path).toBe('Observation.value[x]');
       expect(integer.sliceName).toBe('valueInteger');
       expect(integer.min).toBe(0);
       expect(integer.max).toBe('1');

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -89,7 +89,6 @@ describe('StructureDefinition', () => {
     });
   });
 
-  // Should get top level for '' element
   describe('#findElementByPath', () => {
     let jsonRespRate: any;
     let respRate: StructureDefinition;
@@ -125,7 +124,7 @@ describe('StructureDefinition', () => {
       expect(refRangeLow.id).toBe('Observation.referenceRange.low');
     });
 
-    it('should find the base element by a null path', () => {
+    it('should find the base element by an empty path', () => {
       const observationElement = observation.findElementByPath('', getResolver(defs));
       expect(observationElement).toBeDefined();
       expect(observationElement.id).toBe('Observation');
@@ -187,7 +186,10 @@ describe('StructureDefinition', () => {
       const valueQuantity = observation.findElementByPath('valueQuantity', getResolver(defs));
       expect(valueQuantity).toBeDefined();
       expect(valueQuantity.id).toBe('Observation.value[x]:valueQuantity');
+      expect(valueQuantity.sliceName).toBe('valueQuantity');
+      expect(valueQuantity.path).toBe('Observation.value[x]');
       expect(valueX.slicing).toBeDefined();
+      expect(valueX.slicing.discriminator[0]).toEqual({ type: 'type', path: '$this' });
       expect(observation.elements.length).toBe(originalLength + 1);
     });
 
@@ -195,13 +197,15 @@ describe('StructureDefinition', () => {
       const originalLength = observation.elements.length;
       const valueX = observation.findElementByPath('value[x]');
       expect(valueX.slicing).toBeUndefined();
-      const valueQuantity = observation.findElementByPath(
+      const valueQuantitySystem = observation.findElementByPath(
         'valueQuantity.system',
         getResolver(defs)
       );
-      expect(valueQuantity).toBeDefined();
-      expect(valueQuantity.id).toBe('Observation.value[x]:valueQuantity.system');
+      expect(valueQuantitySystem).toBeDefined();
+      expect(valueQuantitySystem.id).toBe('Observation.value[x]:valueQuantity.system');
+      expect(valueQuantitySystem.path).toBe('Observation.value[x].system');
       expect(valueX.slicing).toBeDefined();
+      expect(valueX.slicing.discriminator[0]).toEqual({ type: 'type', path: '$this' });
       expect(observation.elements.length).toBe(originalLength + 8);
     });
 

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -188,6 +188,7 @@ describe('StructureDefinition', () => {
       expect(valueQuantity.id).toBe('Observation.value[x]:valueQuantity');
       expect(valueQuantity.sliceName).toBe('valueQuantity');
       expect(valueQuantity.path).toBe('Observation.value[x]');
+      expect(valueQuantity.min).toBe(0);
       expect(valueX.slicing).toBeDefined();
       expect(valueX.slicing.discriminator[0]).toEqual({ type: 'type', path: '$this' });
       expect(observation.elements.length).toBe(originalLength + 1);

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -1,26 +1,18 @@
 import fs from 'fs';
 import path from 'path';
+import { load } from '../../src/fhirdefs/load';
+import { FHIRDefinitions } from '../../src/fhirdefs/FHIRDefinitions';
 import { StructureDefinition } from '../../src/fhirtypes/StructureDefinition';
 import { ElementDefinition } from '../../src/fhirtypes/ElementDefinition';
+import { getResolver } from '../utils/getResolver';
 
 describe('StructureDefinition', () => {
-  let jsonResourceBundle: Readonly<any>;
+  let defs: FHIRDefinitions;
   let jsonObservation: any;
   let observation: StructureDefinition;
   beforeAll(() => {
-    const resourceFile = path.join(
-      __dirname,
-      '..',
-      '..',
-      'src',
-      'fhirdefs',
-      'fhir-4.0.0',
-      'profiles-resources.json'
-    );
-    jsonResourceBundle = JSON.parse(fs.readFileSync(resourceFile, 'utf-8'));
-    jsonObservation = jsonResourceBundle.entry.find(
-      (e: any) => e.resource && e.resource.id === 'Observation'
-    ).resource;
+    defs = load('4.0.0');
+    jsonObservation = defs.findResource('Observation');
   });
   beforeEach(() => {
     observation = StructureDefinition.fromJSON(jsonObservation);
@@ -97,11 +89,130 @@ describe('StructureDefinition', () => {
     });
   });
 
+  // Should get top level for '' element
   describe('#findElementByPath', () => {
-    it('should find an element by path', () => {
-      const valueX = observation.findElementByPath('value[x]');
+    let jsonRespRate: any;
+    let respRate: StructureDefinition;
+    beforeAll(() => {
+      jsonRespRate = defs.findResource('resprate');
+    });
+    beforeEach(() => {
+      respRate = StructureDefinition.fromJSON(jsonRespRate);
+    });
+
+    // Simple paths (no brackets)
+    it('should find an element by a path that exists', () => {
+      const status = observation.findElementByPath('status', getResolver(defs));
+      expect(status).toBeDefined();
+      expect(status.id).toBe('Observation.status');
+    });
+
+    it('should find a choice element by a path that exists', () => {
+      const valueX = observation.findElementByPath('value[x]', getResolver(defs));
       expect(valueX).toBeDefined();
-      expect(valueX.short).toBe('Actual result');
+      expect(valueX.id).toBe('Observation.value[x]');
+    });
+
+    it('should find an element with children by a path that exists', () => {
+      const refRange = respRate.findElementByPath('referenceRange', getResolver(defs));
+      expect(refRange).toBeDefined();
+      expect(refRange.id).toBe('Observation.referenceRange');
+    });
+
+    it('should find a child element by a path that exists', () => {
+      const refRangeLow = respRate.findElementByPath('referenceRange.low', getResolver(defs));
+      expect(refRangeLow).toBeDefined();
+      expect(refRangeLow.id).toBe('Observation.referenceRange.low');
+    });
+
+    it('should find the base element by a null path', () => {
+      const observationElement = observation.findElementByPath('', getResolver(defs));
+      expect(observationElement).toBeDefined();
+      expect(observationElement.id).toBe('Observation');
+    });
+
+    it('should not find an element by non-existent path', () => {
+      const undefinedEl = observation.findElementByPath('foo', getResolver(defs));
+      expect(undefinedEl).toBeUndefined();
+    });
+
+    // References
+    it('should find a reference choice by path', () => {
+      const basedOnNoChoice = observation.findElementByPath('basedOn', getResolver(defs));
+      const basedOnChoice = observation.findElementByPath(
+        'basedOn[MedicationRequest]',
+        getResolver(defs)
+      );
+      expect(basedOnChoice).toBeDefined();
+      expect(basedOnChoice.id).toBe('Observation.basedOn');
+      expect(basedOnChoice).toBe(basedOnNoChoice);
+    });
+
+    it('should not find an incorrect reference choice by path', () => {
+      const basedOn = observation.findElementByPath('basedOn[foo]', getResolver(defs));
+      expect(basedOn).toBeUndefined();
+    });
+
+    // Slicing
+    it('should find a sliced element by path', () => {
+      const VSCat = respRate.findElementByPath('category[VSCat]', getResolver(defs));
+      expect(VSCat).toBeDefined();
+      expect(VSCat.id).toBe('Observation.category:VSCat');
+    });
+
+    it('should find a child of a sliced element by path', () => {
+      const VSCatID = respRate.findElementByPath('category[VSCat].id', getResolver(defs));
+      expect(VSCatID).toBeDefined();
+      expect(VSCatID.id).toBe('Observation.category:VSCat.id');
+    });
+
+    it('should find a re-sliced element by path', () => {
+      const jsonReslice = JSON.parse(
+        fs.readFileSync(
+          path.join(__dirname, '../fhirdefs/testdefs/patient-telecom-reslice-profile.json'),
+          'utf-8'
+        )
+      );
+      const reslice = StructureDefinition.fromJSON(jsonReslice);
+      const emailWorkEmail = reslice.findElementByPath('telecom[email][workEmail]');
+      expect(emailWorkEmail).toBeDefined();
+      expect(emailWorkEmail.sliceName).toBe('email/workEmail');
+    });
+
+    // Choices
+    it('should make explicit a non-existent choice element by path', () => {
+      const originalLength = observation.elements.length;
+      const valueX = observation.findElementByPath('value[x]');
+      expect(valueX.slicing).toBeUndefined();
+      const valueQuantity = observation.findElementByPath('valueQuantity', getResolver(defs));
+      expect(valueQuantity).toBeDefined();
+      expect(valueQuantity.id).toBe('Observation.value[x]:valueQuantity');
+      expect(valueX.slicing).toBeDefined();
+      expect(observation.elements.length).toBe(originalLength + 1);
+    });
+
+    it('should make explicit a non-existent choice element by child path', () => {
+      const originalLength = observation.elements.length;
+      const valueX = observation.findElementByPath('value[x]');
+      expect(valueX.slicing).toBeUndefined();
+      const valueQuantity = observation.findElementByPath(
+        'valueQuantity.system',
+        getResolver(defs)
+      );
+      expect(valueQuantity).toBeDefined();
+      expect(valueQuantity.id).toBe('Observation.value[x]:valueQuantity.system');
+      expect(valueX.slicing).toBeDefined();
+      expect(observation.elements.length).toBe(originalLength + 8);
+    });
+
+    // Unfolding
+    it('should find an element that must be unfolded by path', () => {
+      const originalLength = observation.elements.length;
+      const codeText = observation.findElementByPath('code.text', getResolver(defs));
+      expect(codeText).toBeDefined();
+      expect(codeText.id).toBe('Observation.code.text');
+      expect(codeText.short).toBe('Plain text representation of the concept');
+      expect(observation.elements.length).toBe(originalLength + 4);
     });
   });
 });


### PR DESCRIPTION
This fleshes out the implementation of the `findElementByPath` function by accounting for finding paths that use bracket syntax, or may refer to a choice element that does not explicitly exist. There are multiple private helper functions that are called in this function that are also added to  the `StructureDefinition` class. This PR also adds tests for `findElementByPath`. Finally, there is a minor change in `ElementDefinition` which was made to be consistent with the handling of choice elements in `findElementByPath` and (we believe) in FHIR.