### PR TITLE
Adding exporting of cardinality rules

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -23,7 +23,7 @@ export class StructureDefinitionExporter {
     structDef: StructureDefinition,
     fshDefinition: Profile | Extension,
     tank: FSHTank
-  ) {
+  ): void {
     structDef.name = fshDefinition.name;
     structDef.id = fshDefinition.id;
     structDef.url = `${tank.packageJSON.canonical}/StructureDefinition/${structDef.id}`;
@@ -36,7 +36,7 @@ export class StructureDefinitionExporter {
    * @param {StructureDefinition} structDef - The StructureDefinition to set rules on
    * @param {Profile | Extension} fshDefinition - The Profile or Extension we are exporting
    */
-  private setRules(structDef: StructureDefinition, fshDefinition: Profile | Extension) {
+  private setRules(structDef: StructureDefinition, fshDefinition: Profile | Extension): void {
     for (const rule of fshDefinition.rules) {
       const element = structDef.findElementByPath(rule.path);
       if (element) {

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -59,7 +59,7 @@ export class StructureDefinition {
   /**
    * A base clone of the Structure Definition from before any rules were applied
    */
-  _baseStructureDefinition: StructureDefinition;
+  private _baseStructureDefinition: StructureDefinition;
 
   /**
    * Constructs a StructureDefinition with a root element.

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -57,6 +57,11 @@ export class StructureDefinition {
   elements: ElementDefinition[];
 
   /**
+   * A base clone of the Structure Definition from before any rules were applied
+   */
+  _baseStructureDefinition: StructureDefinition;
+
+  /**
    * Constructs a StructureDefinition with a root element.
    */
   constructor() {
@@ -69,6 +74,13 @@ export class StructureDefinition {
     root.isModifier = false;
     root.isSummary = false;
     this.elements = [root];
+  }
+
+  /**
+   * Get the base Structure Definition before any rules were applied
+   */
+  getBaseStructureDefinition() {
+    return this._baseStructureDefinition;
   }
 
   /**
@@ -252,6 +264,8 @@ export class StructureDefinition {
         sd.elements.push(ed);
       }
     }
+    // Keep a clone of the base structure definition for comparison once rules are applied
+    sd._baseStructureDefinition = cloneDeep(sd);
     return sd;
   }
 

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -112,21 +112,20 @@ describe('StructureDefinitionExporter', () => {
 
   // Card Rule
   it('should apply a correct card rule', () => {
-    const baseProfile = new Profile('Foo');
-    baseProfile.parent = 'Observation';
-    const changedProfile = new Profile('Foo');
-    changedProfile.parent = 'Observation';
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
 
     const rule = new CardRule('subject');
     rule.min = 1;
     rule.max = '1';
-    changedProfile.rules.push(rule);
+    profile.rules.push(rule);
 
-    const baseStructDef = exporter.exportStructDef(baseProfile, input);
-    const changedStructDef = exporter.exportStructDef(changedProfile, input);
+    const sd = exporter.exportStructDef(profile, input);
+    const baseStructDef = sd.getBaseStructureDefinition();
 
     const baseCard = baseStructDef.findElement('Observation.subject');
-    const changedCard = changedStructDef.findElement('Observation.subject');
+    const changedCard = sd.findElement('Observation.subject');
+
     expect(baseCard.min).toBe(0);
     expect(baseCard.max).toBe('1');
     expect(changedCard.min).toBe(1);
@@ -135,21 +134,20 @@ describe('StructureDefinitionExporter', () => {
 
   it('should not apply an incorrect card rule', () => {
     // TODO: this should check for emitting an error once logging is setup
-    const baseProfile = new Profile('Foo');
-    baseProfile.parent = 'Observation';
-    const changedProfile = new Profile('Foo');
-    changedProfile.parent = 'Observation';
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
 
     const rule = new CardRule('status');
     rule.min = 0;
     rule.max = '1';
-    changedProfile.rules.push(rule);
+    profile.rules.push(rule);
 
-    const baseStructDef = exporter.exportStructDef(baseProfile, input);
-    const changedStructDef = exporter.exportStructDef(changedProfile, input);
+    const sd = exporter.exportStructDef(profile, input);
+    const baseStructDef = sd.getBaseStructureDefinition();
 
     const baseCard = baseStructDef.findElement('Observation.status');
-    const changedCard = changedStructDef.findElement('Observation.status');
+    const changedCard = sd.findElement('Observation.status');
+
     expect(baseCard.min).toBe(1);
     expect(baseCard.max).toBe('1');
     expect(changedCard.min).toBe(1);

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -2,6 +2,7 @@ import { StructureDefinitionExporter } from '../../src/export';
 import { FSHTank, FSHDocument } from '../../src/import';
 import { FHIRDefinitions, load } from '../../src/fhirdefs';
 import { Profile, Extension } from '../../src/fshtypes';
+import { CardRule } from '../../src/fshtypes/rules';
 
 describe('StructureDefinitionExporter', () => {
   let defs: FHIRDefinitions;
@@ -94,5 +95,64 @@ describe('StructureDefinitionExporter', () => {
     expect(() => {
       exporter.exportStructDef(extension, input);
     }).toThrow('Parent Bar not found for Foo');
+  });
+
+  // Rules
+  it('should emit an error and continue when the path is not found', () => {
+    // TODO: This should check for emitting an error once we have logging
+    const profile = new Profile('Foo');
+    const rule = new CardRule('fakePath');
+    rule.min = 0;
+    rule.max = '1';
+    profile.rules.push(rule);
+    const structDef = exporter.exportStructDef(profile, input);
+    expect(structDef).toBeDefined();
+    expect(structDef.type).toBe('Resource');
+  });
+
+  // Card Rule
+  it('should apply a correct card rule', () => {
+    const baseProfile = new Profile('Foo');
+    baseProfile.parent = 'Observation';
+    const changedProfile = new Profile('Foo');
+    changedProfile.parent = 'Observation';
+
+    const rule = new CardRule('subject');
+    rule.min = 1;
+    rule.max = '1';
+    changedProfile.rules.push(rule);
+
+    const baseStructDef = exporter.exportStructDef(baseProfile, input);
+    const changedStructDef = exporter.exportStructDef(changedProfile, input);
+
+    const baseCard = baseStructDef.findElement('Observation.subject');
+    const changedCard = changedStructDef.findElement('Observation.subject');
+    expect(baseCard.min).toBe(0);
+    expect(baseCard.max).toBe('1');
+    expect(changedCard.min).toBe(1);
+    expect(changedCard.max).toBe('1');
+  });
+
+  it('should not apply an incorrect card rule', () => {
+    // TODO: this should check for emitting an error once logging is setup
+    const baseProfile = new Profile('Foo');
+    baseProfile.parent = 'Observation';
+    const changedProfile = new Profile('Foo');
+    changedProfile.parent = 'Observation';
+
+    const rule = new CardRule('status');
+    rule.min = 0;
+    rule.max = '1';
+    changedProfile.rules.push(rule);
+
+    const baseStructDef = exporter.exportStructDef(baseProfile, input);
+    const changedStructDef = exporter.exportStructDef(changedProfile, input);
+
+    const baseCard = baseStructDef.findElement('Observation.status');
+    const changedCard = changedStructDef.findElement('Observation.status');
+    expect(baseCard.min).toBe(1);
+    expect(baseCard.max).toBe('1');
+    expect(changedCard.min).toBe(1);
+    expect(changedCard.max).toBe('1');
   });
 });


### PR DESCRIPTION
This adds exporting of cardinality rules onto a Structure Definition. Note that the code to `constrainCardinality` already existed, and had its own tests for validating a cardinality. This just uses that function in the `StructureDefinitionExporter`, and tests that the function is being used correctly.