### PR TITLE
Update prettier to 1.19.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4376,9 +4376,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jest": "^24.9.0",
     "jest-extended": "^0.11.2",
     "opener": "^1.5.1",
-    "prettier": "1.18.2",
+    "prettier": "1.19.1",
     "ts-jest": "^24.1.0",
     "ts-node": "^8.4.1",
     "typescript": "^3.7.2"


### PR DESCRIPTION
As it turns out, prettier was not working with the new TypeScript 3.7 features (oops).  I missed updating it in my last PR because it does not use wildcards (per prettier recommendation).

This updates it to 1.19.1 to gain support for the new TypeScript 3.7 features.  You'll need to quit and re-launch VS Code after pulling this down in order for it to be used in the VS Code plugin.

One review should be more than enough!