### PR TITLE
Adding function to get reference name from a path

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -372,6 +372,24 @@ export class StructureDefinition {
     });
     return matchingRefElement;
   }
+
+  /**
+   * Gets the specific reference being referred to by a path with brackets
+   * @param {string} path - The path
+   * @param {ElementDefinition} element - The element that may contain the reference
+   * @returns {string} - The name of the reference if it exists, else undefined
+   */
+  getReferenceName(path: string, element: ElementDefinition): string {
+    const parsedPath = this.parseFSHPath(path);
+    const pathEnd = parsedPath.slice(-1)[0];
+    if (pathEnd.brackets) {
+      const refElement = this.findMatchingRef(pathEnd, [element]);
+      if (refElement) {
+        return pathEnd.brackets.slice(-1)[0];
+      }
+    }
+    return;
+  }
 }
 
 export type StructureDefinitionMapping = {

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -220,4 +220,26 @@ describe('StructureDefinition', () => {
       expect(observation.elements.length).toBe(originalLength + 4);
     });
   });
+
+  describe('#getReferenceName', () => {
+    let basedOn: ElementDefinition;
+    beforeEach(() => {
+      basedOn = observation.findElement('Observation.basedOn');
+    });
+
+    it('should find the target when it exists', () => {
+      const refTarget = observation.getReferenceName('basedOn[MedicationRequest]', basedOn);
+      expect(refTarget).toBe('MedicationRequest');
+    });
+
+    it('should not find the target when it does not exist', () => {
+      const refTarget = observation.getReferenceName('basedOn[foo]', basedOn);
+      expect(refTarget).toBeUndefined();
+    });
+
+    it('should not find the target when there are no brackets', () => {
+      const refTarget = observation.getReferenceName('basedOn', basedOn);
+      expect(refTarget).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
This adds a `getReferenceName` function, that will take a `path` and an `ElementDefinition` and check if the end of that `path` has brackets that select a reference on the `ElementDefintion`. If this is the case, the name of the reference that is being selected is returned.