### PR TITLE
Basic CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ pids
 logs
 results
 tmp
+out
 
 # Build
 public/css/main.css

--- a/package-lock.json
+++ b/package-lock.json
@@ -438,6 +438,14 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.0.1.tgz",
+      "integrity": "sha512-J00cVDALmi/hJOYsunyT52Hva5TnJeKP5yd1r+mH/ZU0mbYZflR0Z5kw5kITtKTRYMhm1JMClOFYdHnQszEvqw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -490,11 +498,18 @@
       "integrity": "sha512-7lX5bZFO3YG3AG0XVIm5L1SB6wDLtuaJksTkTWrux3/XwCZgw3MPWZBt3Jgj0w98uqUXWVypT2msxo0A1t22lw==",
       "dev": true
     },
+    "@types/mkdirp": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
+      "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "12.12.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
-      "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA==",
-      "dev": true
+      "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -1141,11 +1156,9 @@
       }
     },
     "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.0.1.tgz",
+      "integrity": "sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -1921,6 +1934,21 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2555,8 +2583,7 @@
     "graceful-fs": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
-      "dev": true
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
     },
     "growly": {
       "version": "1.3.0",
@@ -3705,6 +3732,14 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -3941,7 +3976,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -3949,8 +3983,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -4294,6 +4327,15 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -4392,6 +4434,11 @@
         "ansi-styles": "^3.2.0",
         "react-is": "^16.8.4"
       }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "progress": {
       "version": "2.0.3",
@@ -5376,6 +5423,15 @@
       "requires": {
         "commander": "~2.20.3",
         "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "union-value": {
@@ -5389,6 +5445,11 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -5450,6 +5511,21 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "requires": {
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
+      }
     },
     "util.promisify": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -498,14 +498,6 @@
       "integrity": "sha512-7lX5bZFO3YG3AG0XVIm5L1SB6wDLtuaJksTkTWrux3/XwCZgw3MPWZBt3Jgj0w98uqUXWVypT2msxo0A1t22lw==",
       "dev": true
     },
-    "@types/mkdirp": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
-      "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "12.12.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1934,11 +1934,6 @@
         "map-cache": "^0.2.2"
       }
     },
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
-    },
     "fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -3976,6 +3971,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -3983,7 +3979,8 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
@@ -4327,15 +4324,6 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
-    "path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-      "requires": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -4434,11 +4422,6 @@
         "ansi-styles": "^3.2.0",
         "react-is": "^16.8.4"
       }
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "progress": {
       "version": "2.0.3",
@@ -5511,21 +5494,6 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
-    },
-    "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "requires": {
-        "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
-      }
     },
     "util.promisify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Sushi Unshortens Short Hand Inputs (FSH Compiler)",
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist && tsc && cp -r src/fhirdefs/fhir-4.0.1 dist/fhirdefs/fhir-4.0.1",
     "build:watch": "tsc -w",
     "build:grammar": "bash ./antlr/gradlew -p ./antlr generateGrammarSource",
     "test": "jest --coverage",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "type": "git",
     "url": "https://github.com/standardhealth/sushi.git"
   },
+  "main": "./dist/app.js",
+  "bin": {
+    "sushi": "./dist/app.js"
+  },
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/antlr4": "^4.7.0",
@@ -45,7 +49,14 @@
     "typescript": "^3.7.2"
   },
   "dependencies": {
+    "@types/fs-extra": "^8.0.1",
+    "@types/mkdirp": "^0.5.2",
     "antlr4": "^4.7.2",
-    "lodash": "^4.17.15"
+    "commander": "^4.0.1",
+    "fs": "0.0.1-security",
+    "fs-extra": "^8.1.0",
+    "lodash": "^4.17.15",
+    "mkdirp": "^0.5.1",
+    "path": "^0.12.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check": "npm run test && npm run lint && npm run prettier"
   },
   "contributors": [
+    "Julia Afeltra <jafeltra@mitre.org>",
     "Nick Freiter <nfreiter@mitre.org>",
     "Dylan Mahalingam <kmahalingam@mitre.org>",
     "Chris Moesel <cmoesel@mitre.org>",
@@ -53,10 +54,7 @@
     "@types/mkdirp": "^0.5.2",
     "antlr4": "^4.7.2",
     "commander": "^4.0.1",
-    "fs": "0.0.1-security",
     "fs-extra": "^8.1.0",
-    "lodash": "^4.17.15",
-    "mkdirp": "^0.5.1",
-    "path": "^0.12.7"
+    "lodash": "^4.17.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   },
   "dependencies": {
     "@types/fs-extra": "^8.0.1",
-    "@types/mkdirp": "^0.5.2",
     "antlr4": "^4.7.2",
     "commander": "^4.0.1",
     "fs-extra": "^8.1.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -41,7 +41,6 @@ for (const file of files) {
   }
 }
 
-
 let config: any;
 try {
   config = JSON.parse(fs.readFileSync(path.join(input, 'package.json'), 'utf8').toString());
@@ -76,4 +75,6 @@ fs.writeFileSync(
   'utf8'
 );
 
-console.info(`Exported ${outPackage.profiles.length} profile(s) and ${outPackage.extensions.length} extension(s).`);
+console.info(
+  `Exported ${outPackage.profiles.length} profile(s) and ${outPackage.extensions.length} extension(s).`
+);

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,31 +4,42 @@ import path from 'path';
 import fs from 'fs-extra';
 import mkdirp from 'mkdirp';
 import program from 'commander';
+import { importText, FSHDocument, FSHTank } from './import';
+import { exportFHIR, Package } from './export';
 
 let input: string;
 
 program
-    .name('sushi')
-    .usage('<path-to-fsh-defs> [options]')
-    .option('-o, --out <out>', `the path to the output folder`, path.join('.', 'out'))
-    .option('-c, --config <config>', 'the name of the config file', 'config.json')
-    .arguments('<path-to-fsh-defs>')
-    .action(function (pathToFshDefs) {
-        input = pathToFshDefs;
-    })
-    .parse(process.argv);
-
-console.log('Running SUSHI!');
+  .name('sushi')
+  .usage('<path-to-fsh-defs> [options]')
+  .option('-o, --out <out>', 'the path to the output folder', path.join('.', 'out'))
+  .option('-c, --config <config>', 'the name of the config file', 'config.json')
+  .arguments('<path-to-fsh-defs>')
+  .action(function(pathToFshDefs) {
+    input = pathToFshDefs;
+  })
+  .parse(process.argv);
 
 // Check that input folder is specified
 if (!input) {
-    console.error('Missing path to FSH definition folder');
-    program.help();
-  }
+  console.error('Missing path to FSH definition folder');
+  program.help();
+}
 
 mkdirp.sync(program.out);
-console.log('Created output directory.');
 
+const files: string[] = fs.readdirSync(input, 'utf8');
+const docs: FSHDocument[] = [];
+for (const file of files) {
+  if (file.endsWith('.fsh')) {
+    const fileContent: string = fs.readFileSync(path.join(input, file), 'utf8');
+    const doc: FSHDocument = importText(fileContent, file);
+    if (doc) docs.push(doc);
+  }
+}
 
-fs.writeFileSync(path.join(program.out, 'test.json'), fs.readFileSync(path.join(input, program.config)));
-console.log('Wrote test output file.');
+const config = JSON.parse(fs.readFileSync(path.join(input, program.config)).toString());
+const tank: FSHTank = new FSHTank(docs, config);
+const outPackage: Package = exportFHIR(tank);
+
+console.log(outPackage);

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import path from 'path';
+import fs from 'fs-extra';
+import mkdirp from 'mkdirp';
+import program from 'commander';
+
+let input: string;
+
+program
+    .name('sushi')
+    .usage('<path-to-fsh-defs> [options]')
+    .option('-o, --out <out>', `the path to the output folder`, path.join('.', 'out'))
+    .option('-c, --config <config>', 'the name of the config file', 'config.json')
+    .arguments('<path-to-fsh-defs>')
+    .action(function (pathToFshDefs) {
+        input = pathToFshDefs;
+    })
+    .parse(process.argv);
+
+console.log('Running SUSHI!');
+
+// Check that input folder is specified
+if (!input) {
+    console.error('Missing path to FSH definition folder');
+    program.help();
+  }
+
+mkdirp.sync(program.out);
+console.log('Created output directory.');
+
+
+fs.writeFileSync(path.join(program.out, 'test.json'), fs.readFileSync(path.join(input, program.config)));
+console.log('Wrote test output file.');

--- a/src/export/FHIRExporter.ts
+++ b/src/export/FHIRExporter.ts
@@ -21,6 +21,6 @@ export class FHIRExporter {
   export(tank: FSHTank): Package {
     const profileDefs = this.profileExporter.export(tank);
     const extensionDefs = this.extensionExporter.export(tank);
-    return new Package(profileDefs, extensionDefs, tank.packageJSON);
+    return new Package(profileDefs, extensionDefs, tank.config);
   }
 }

--- a/src/export/Package.ts
+++ b/src/export/Package.ts
@@ -4,6 +4,6 @@ export class Package {
   constructor(
     public readonly profiles: StructureDefinition[],
     public readonly extensions: StructureDefinition[],
-    public readonly packageJSON: any
+    public readonly config: any
   ) {}
 }

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -26,7 +26,7 @@ export class StructureDefinitionExporter {
   ): void {
     structDef.name = fshDefinition.name;
     structDef.id = fshDefinition.id;
-    structDef.url = `${tank.packageJSON.canonical}/StructureDefinition/${structDef.id}`;
+    structDef.url = `${tank.config.canonical}/StructureDefinition/${structDef.id}`;
     if (fshDefinition.title) structDef.title = fshDefinition.title;
     if (fshDefinition.description) structDef.description = fshDefinition.description;
   }

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -38,7 +38,14 @@ export class StructureDefinitionExporter {
    */
   private setRules(structDef: StructureDefinition, fshDefinition: Profile | Extension): void {
     for (const rule of fshDefinition.rules) {
-      const element = structDef.findElementByPath(rule.path);
+      const element = structDef.findElementByPath(rule.path, (type: string):
+        | StructureDefinition
+        | undefined => {
+        const json = this.FHIRDefs.find(type);
+        if (json) {
+          return StructureDefinition.fromJSON(json);
+        }
+      });
       if (element) {
         try {
           if (rule instanceof CardRule) {

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -38,14 +38,7 @@ export class StructureDefinitionExporter {
    */
   private setRules(structDef: StructureDefinition, fshDefinition: Profile | Extension): void {
     for (const rule of fshDefinition.rules) {
-      const element = structDef.findElementByPath(rule.path, (type: string):
-        | StructureDefinition
-        | undefined => {
-        const json = this.FHIRDefs.find(type);
-        if (json) {
-          return StructureDefinition.fromJSON(json);
-        }
-      });
+      const element = structDef.findElementByPath(rule.path, this.resolve.bind(this));
       if (element) {
         try {
           if (rule instanceof CardRule) {
@@ -59,6 +52,18 @@ export class StructureDefinitionExporter {
           `No element found at path ${rule.path} for ${fshDefinition.name}, skipping rule`
         );
       }
+    }
+  }
+
+  /**
+   * Looks through FHIR definitions to find the definition of the passed-in type
+   * @param {string} type - The type to search for the FHIR definition of
+   * @returns {StructureDefinition | undefined}
+   */
+  private resolve(type: string): StructureDefinition | undefined {
+    const json = this.FHIRDefs.find(type);
+    if (json) {
+      return StructureDefinition.fromJSON(json);
     }
   }
 

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -1,4 +1,4 @@
-import capitalize from 'lodash/capitalize';
+import upperFirst from 'lodash/upperFirst';
 import cloneDeep from 'lodash/cloneDeep';
 import { ElementDefinition, ElementDefinitionType, ResolveFn } from './ElementDefinition';
 import { Meta } from './specialTypes';
@@ -322,7 +322,7 @@ export class StructureDefinition {
     const matchingXElement = elements.find(e => {
       if (e.path.endsWith('[x]')) {
         for (const t of e.type) {
-          if (`${e.path.slice(0, -3)}${capitalize(t.code)}` === fhirPath) {
+          if (`${e.path.slice(0, -3)}${upperFirst(t.code)}` === fhirPath) {
             matchingType = t;
             return true;
           }

--- a/src/import/FSHTank.ts
+++ b/src/import/FSHTank.ts
@@ -1,5 +1,5 @@
 import { FSHDocument } from './FSHDocument';
 
 export class FSHTank {
-  constructor(public readonly docs: FSHDocument[], public readonly packageJSON: any) {}
+  constructor(public readonly docs: FSHDocument[], public readonly config: any) {}
 }


### PR DESCRIPTION
This adds support for running a basic CLI, which imports a directory of FSH definitions, and outputs a directory of these parsed into StructureDefinition files. Also fixes some export bugs along the way.

In order to run this, you must do the following:

- Install `ts-node` globally through `npm`
- From the `sushi` directory, run `ts-node src/app.ts ./pathToFSHDefs/`

This will create an `out` directory in `sushi` which contains the output StructureDefinition files from those parsed definitions.

In order for this to work, the definitions directory must contain a valid `package.json` configuration file in it.

The command also has a `-o` flag that allows for configuring the name of the output directory.

When this is deployed, the `sushi` command can be used directly, like `sushi ./pathToFSHDefs/`.

I will send reviewers the set of input files I used for testing.