### PR TITLE
Fix differentials on exported StructureDefinitions

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -70,6 +70,8 @@ export class StructureDefinitionExporter {
     } else {
       throw new ParentNotDefinedError(fshDefinition.name, parentName);
     }
+    // Capture the orginal elements so that any further changes are reflected in the differential
+    structDef.captureOriginalElements();
     this.setMetadata(structDef, fshDefinition, tank);
     this.setRules(structDef, fshDefinition);
     // Set the rules

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -217,6 +217,23 @@ export class StructureDefinition {
   }
 
   /**
+   * Each ElementDefinition is capable of producing its own differential, based on differences
+   * from a stored "original".  This function captures the current state of each element as the
+   * "original", so any further changes made would be captured in the generated differentials.
+   */
+  captureOriginalElements(): void {
+    this.elements.forEach(e => e.captureOriginal());
+  }
+
+  /**
+   * Clears the stored "original" state for each ElementDefnition, resulting in every property
+   * being considered new, and reflected in the generated differentials.
+   */
+  clearOriginalElements(): void {
+    this.elements.forEach(e => e.clearOriginal());
+  }
+
+  /**
    * Exports the StructureDefinition to a properly formatted FHIR JSON representation.
    * @returns {any} the FHIR JSON representation of the StructureDefinition
    */

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -153,4 +153,27 @@ describe('StructureDefinitionExporter', () => {
     expect(changedCard.min).toBe(1);
     expect(changedCard.max).toBe('1');
   });
+
+  // toJSON
+  it('should correctly generate a diff containing only changed elements', () => {
+    // We already have separate tests for the differentials, so this just ensures that the
+    // StructureDefinition is setup correctly to produce accurate differential elements.
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+
+    const rule = new CardRule('subject');
+    rule.min = 1;
+    rule.max = '1';
+    profile.rules.push(rule);
+
+    const sd = exporter.exportStructDef(profile, input);
+    const json = sd.toJSON();
+
+    expect(json.differential.element).toHaveLength(1);
+    expect(json.differential.element[0]).toEqual({
+      id: 'Observation.subject',
+      path: 'Observation.subject',
+      min: 1
+    });
+  });
 });


### PR DESCRIPTION
The StructureDefinition's differential elements should reflect only those things that changed from the original.  In order to support this, we need to "capture" the original after we load it but before we make modifications to it.