### PR TITLE
Fixes needed to support npm publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "sushi",
+  "name": "fsh-sushi",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "sushi",
+  "name": "fsh-sushi",
   "version": "0.1.0",
   "description": "Sushi Unshortens Short Hand Inputs (FSH Compiler)",
   "scripts": {
     "build": "rm -rf dist && tsc && cp -r src/fhirdefs/fhir-4.0.1 dist/fhirdefs/fhir-4.0.1",
     "build:watch": "tsc -w",
-    "build:grammar": "bash ./antlr/gradlew -p ./antlr generateGrammarSource",
+    "build:grammar": "bash antlr/gradlew -p antlr generateGrammarSource",
     "test": "jest --coverage",
     "test:watch": "npm run test -- --watchAll",
     "coverage": "opener coverage/lcov-report/index.html",
@@ -13,7 +13,9 @@
     "lint:fix": "tsc --noEmit && eslint \"**/*.{js,ts}\" --quiet --fix",
     "prettier": "prettier --check \"**/*.{js,ts}\"",
     "prettier:fix": "prettier --write \"**/*.{js,ts}\"",
-    "check": "npm run test && npm run lint && npm run prettier"
+    "check": "npm run test && npm run lint && npm run prettier",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run check"
   },
   "contributors": [
     "Julia Afeltra <jafeltra@mitre.org>",
@@ -26,10 +28,15 @@
     "type": "git",
     "url": "https://github.com/standardhealth/sushi.git"
   },
-  "main": "./dist/app.js",
+  "main": "dist/app.js",
   "bin": {
-    "sushi": "./dist/app.js"
+    "sushi": "dist/app.js"
   },
+  "types": "dist/app.d.ts",
+  "files": [
+    "dist/**/*.{js,json,d.ts}",
+    "antlr/**/*.g4"
+  ],
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/antlr4": "^4.7.0",

--- a/src/import/importText.ts
+++ b/src/import/importText.ts
@@ -1,7 +1,7 @@
 import { InputStream, CommonTokenStream } from 'antlr4/index';
-import { FSHLexer } from '../../src/import/generated/FSHLexer';
-import { FSHParser } from '../../src/import/generated/FSHParser';
-import { DocContext } from '../../src/import/parserContexts';
+import { FSHLexer } from './generated/FSHLexer';
+import { FSHParser } from './generated/FSHParser';
+import { DocContext } from './parserContexts';
 import { FSHImporter } from './FSHImporter';
 import { FSHDocument } from './FSHDocument';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */


### PR DESCRIPTION
In order to support npm publish we need to ensure that we do publish the right things (compiled js, json, and *.d.ts definition files) and we don't publish the wrong things (original ts files, map files, antlr jar, etc).  We also need to use a name that isn't already in use at npm (sushi *is* already in use).

To support this, the following changes were made:
- package.json: changed "name" to "fsh-sushi"
- package.json: added a "prepare" script to run "npm build" before packaging (to ensure compiled js is up to date)
- package.json: added a "prepublishOnly" script to run "npm run check" before publishing (to ensure we don't publish code w/ errors)
- package.json: added "files" to whitelist what we want published
- package.json: added "types" to point to the main *.d.ts file (currently empty, but that's ok)
- tsconfig.json: set "declaration" to true to generate .d.ts files in dist
- importText.ts: fixed bad relative paths in import statements

To test this, run:
```
npm pack
```

This will show you the list of things going into the package (which should _mainly_ be js, json, and d.ts file in dist -- as well as the FSH.g4 file).  It will also produce a `fsh-sushi-0.1.0.tgz` file.

To test the package itself, run:
```
npm install -g fsh-sushi
```

After this, you should be able to run sushi on the commandline:
```
sushi --help
```
or
```
sushi ./path/to/fshtank
```

When you're done, if you wish, you can uninstall it:
```
npm remove -g fsh-sushi
```