### PR TITLE
Add OnlyRule and corresponding tests

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -3,7 +3,7 @@ import { StructureDefinition, ElementDefinitionBindingStrength } from '../fhirty
 import { Profile, Extension } from '../fshtypes';
 import { FSHTank } from '../import';
 import { ParentNotDefinedError } from '../errors/ParentNotDefinedError';
-import { CardRule, FlagRule, ValueSetRule } from '../fshtypes/rules';
+import { CardRule, FlagRule, OnlyRule, ValueSetRule } from '../fshtypes/rules';
 import { logger } from '../utils/FSHLogger';
 
 /**
@@ -46,6 +46,9 @@ export class StructureDefinitionExporter {
             element.constrainCardinality(rule.min, rule.max);
           } else if (rule instanceof FlagRule) {
             element.applyFlags(rule.mustSupport, rule.summary, rule.modifier);
+          } else if (rule instanceof OnlyRule) {
+            const target = structDef.getReferenceName(rule.path, element);
+            element.constrainType(rule.types, this.resolve.bind(this), target);
           } else if (rule instanceof ValueSetRule) {
             element.bindToVS(rule.valueSet, rule.strength as ElementDefinitionBindingStrength);
           }


### PR DESCRIPTION
Addresses: https://standardhealthrecord.atlassian.net/browse/CIMPL-114

This adds the OnlyRule to the StructureDefinitionExporter. Tests for the following cases were added:
- Constraining a type
- Constraining a type that is a Reference
- Constraining a specific target of a Reference
- Not constraining an invalid type