### PR TITLE
Fix findElementByPath bug

### DIFF
--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -232,6 +232,22 @@ describe('StructureDefinition', () => {
       expect(observation.elements.length).toBe(originalLength + 8);
     });
 
+    it('should find an already existing explicit choice element with slicing syntax', () => {
+      const originalLength = respRate.elements.length;
+      const valueQuantity = respRate.findElementByPath('value[x][valueQuantity]');
+      expect(valueQuantity).toBeDefined();
+      expect(valueQuantity.id).toBe('Observation.value[x]:valueQuantity');
+      expect(respRate.elements.length).toBe(originalLength);
+    });
+
+    it('should find an already existing explicit choice element with name replacement syntax', () => {
+      const originalLength = respRate.elements.length;
+      const valueQuantity = respRate.findElementByPath('valueQuantity');
+      expect(valueQuantity).toBeDefined();
+      expect(valueQuantity.id).toBe('Observation.value[x]:valueQuantity');
+      expect(respRate.elements.length).toBe(originalLength);
+    });
+
     // Unfolding
     it('should find an element that must be unfolded by path', () => {
       const originalLength = observation.elements.length;


### PR DESCRIPTION
I noticed there was a bug with how we were handling choice elements. If we had an element like `valueQuantity`, we would add a slice on the corresponding `value[x]` element. However, we were adding a slice even when there was already an existing `valueQuantity` slice, resulting in multiple repetitions of the same element. Now we do not re-add the `valueQuantity` slice. If you want to see this in action, you can use master to run the cli on these files https://github.com/HL7/fhir-shorthand/tree/master/dev-days-2019/working-samples. You'll notice in the respRate StructureDefinition, there is a repetition of `value[x]:valueQuantity.id` elements. If you use this branch, you should notice that there is no repetition.