### PR TITLE
Add FixedValueRule and tests

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -3,7 +3,7 @@ import { StructureDefinition, ElementDefinitionBindingStrength } from '../fhirty
 import { Profile, Extension } from '../fshtypes';
 import { FSHTank } from '../import';
 import { ParentNotDefinedError } from '../errors/ParentNotDefinedError';
-import { CardRule, FlagRule, OnlyRule, ValueSetRule } from '../fshtypes/rules';
+import { CardRule, FixedValueRule, FlagRule, OnlyRule, ValueSetRule } from '../fshtypes/rules';
 import { logger } from '../utils/FSHLogger';
 
 /**
@@ -44,6 +44,8 @@ export class StructureDefinitionExporter {
         try {
           if (rule instanceof CardRule) {
             element.constrainCardinality(rule.min, rule.max);
+          } else if (rule instanceof FixedValueRule) {
+            element.fixValue(rule.fixedValue);
           } else if (rule instanceof FlagRule) {
             element.applyFlags(rule.mustSupport, rule.summary, rule.modifier);
           } else if (rule instanceof OnlyRule) {

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -424,8 +424,8 @@ describe('StructureDefinitionExporter', () => {
     expect(constrainedValue.type).toHaveLength(11);
   });
 
-  // FixValue rule
-  it('should apply a correct FixValueRule', () => {
+  // Fixed Value Rule
+  it('should apply a correct FixedValueRule', () => {
     const profile = new Profile('Foo');
     profile.parent = 'Observation';
 
@@ -446,7 +446,7 @@ describe('StructureDefinitionExporter', () => {
     });
   });
 
-  it('should not apply an incorrect FixValueRule', () => {
+  it('should not apply an incorrect FixedValueRule', () => {
     // TODO: this should check for emitting an error once logging is set up
     const profile = new Profile('Foo');
     profile.parent = 'Observation';

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -1,8 +1,14 @@
 import { StructureDefinitionExporter } from '../../src/export';
 import { FSHTank, FSHDocument } from '../../src/import';
 import { FHIRDefinitions, load } from '../../src/fhirdefs';
-import { Profile, Extension } from '../../src/fshtypes';
-import { CardRule, FlagRule, OnlyRule, ValueSetRule } from '../../src/fshtypes/rules';
+import { Profile, Extension, FshCode } from '../../src/fshtypes';
+import {
+  CardRule,
+  FlagRule,
+  OnlyRule,
+  ValueSetRule,
+  FixedValueRule
+} from '../../src/fshtypes/rules';
 
 describe('StructureDefinitionExporter', () => {
   let defs: FHIRDefinitions;
@@ -416,6 +422,47 @@ describe('StructureDefinitionExporter', () => {
 
     expect(baseValue.type).toHaveLength(11);
     expect(constrainedValue.type).toHaveLength(11);
+  });
+
+  // FixValue rule
+  it('should apply a correct FixValueRule', () => {
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+
+    const rule = new FixedValueRule('code');
+    const fixedFshCode = new FshCode('foo', 'http://foo.com');
+    rule.fixedValue = fixedFshCode;
+    profile.rules.push(rule);
+
+    const sd = exporter.exportStructDef(profile, input);
+    const baseStructDef = sd.getBaseStructureDefinition();
+
+    const baseCode = baseStructDef.findElement('Observation.code');
+    const fixedCode = sd.findElement('Observation.code');
+
+    expect(baseCode.patternCodeableConcept).toBeUndefined();
+    expect(fixedCode.patternCodeableConcept).toEqual({
+      coding: [{ code: 'foo', system: 'http://foo.com' }]
+    });
+  });
+
+  it('should not apply an incorrect FixValueRule', () => {
+    // TODO: this should check for emitting an error once logging is set up
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+
+    const rule = new FixedValueRule('code');
+    rule.fixedValue = true; // Incorrect boolean
+    profile.rules.push(rule);
+
+    const sd = exporter.exportStructDef(profile, input);
+    const baseStructDef = sd.getBaseStructureDefinition();
+
+    const baseCode = baseStructDef.findElement('Observation.code');
+    const fixedCode = sd.findElement('Observation.code');
+
+    expect(baseCode.patternCodeableConcept).toBeUndefined();
+    expect(fixedCode.patternCodeableConcept).toBeUndefined(); // Code remains unset
   });
 
   // toJSON


### PR DESCRIPTION
Added the FixedValueRule to StructureDefinitionExporter and two tests. The tests only test that a code is correct fixed to a value and that an incorrect fixed value is not set. I believe that all the tests for the actual `fixValue` function cover all the other cases for calling this function and all its other error cases, but if anyone feels I missed something, I'm happy to add additional tests.