### PR TITLE
Fixing a bug with ordering of elements

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -93,7 +93,7 @@ export class StructureDefinition {
     let lastMatchId = '';
     for (; i < this.elements.length; i++) {
       const currentId = this.elements[i].id;
-      if (element.id.startsWith(currentId)) {
+      if (element.id.startsWith(`${currentId}.`) || element.id.startsWith(`${currentId}:`)) {
         lastMatchId = currentId;
       } else if (!currentId.startsWith(lastMatchId)) {
         break;


### PR DESCRIPTION
Currently, when adding an element, we find an element that starts with the same id, and add the element after that. So an `identifier.value` element should be added after a `identifier` element. However, if there is an `id` element, then the `identifier.value` element would be added after that, since `identifiier.value` starts with `id`. This fixes that issue by checking for a `.` or `:` since these demarcate the complete path elements.