### PR TITLE
Fix issues w/ metadata (derivation, baseDefinition, context) and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fsh-sushi",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2656,9 +2656,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
-      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5555,9 +5555,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
-      "integrity": "sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsh-sushi",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Sushi Unshortens Short Hand Inputs (FSH Compiler)",
   "scripts": {
     "build": "rm -rf dist && tsc && cp -r src/fhirdefs/fhir-4.0.1 dist/fhirdefs/fhir-4.0.1",

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -27,9 +27,14 @@ export class StructureDefinitionExporter {
   ): void {
     structDef.name = fshDefinition.name;
     structDef.id = fshDefinition.id;
-    structDef.url = `${tank.config.canonical}/StructureDefinition/${structDef.id}`;
     if (fshDefinition.title) structDef.title = fshDefinition.title;
     if (fshDefinition.description) structDef.description = fshDefinition.description;
+    // Assuming the starting StructureDefinition was a clone of the parent,
+    // set the baseDefinition to the parent url before re-assiging the url
+    structDef.baseDefinition = structDef.url;
+    // Now re-assign the URL based on canonical and id
+    structDef.url = `${tank.config.canonical}/StructureDefinition/${structDef.id}`;
+    // Set the derivation as appropriate
     if (fshDefinition instanceof Profile || fshDefinition instanceof Extension) {
       structDef.derivation = 'constraint';
     }

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -35,8 +35,20 @@ export class StructureDefinitionExporter {
     // Now re-assign the URL based on canonical and id
     structDef.url = `${tank.config.canonical}/StructureDefinition/${structDef.id}`;
     // Set the derivation as appropriate
-    if (fshDefinition instanceof Profile || fshDefinition instanceof Extension) {
+    if (fshDefinition instanceof Profile) {
       structDef.derivation = 'constraint';
+    } else if (fshDefinition instanceof Extension) {
+      structDef.derivation = 'constraint';
+      if (structDef.context == null) {
+        // NOTE: For now, we always set context to everything, but this will be user-specified
+        // in the future
+        structDef.context = [
+          {
+            type: 'element',
+            expression: 'Element'
+          }
+        ];
+      }
     }
   }
 

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -30,6 +30,9 @@ export class StructureDefinitionExporter {
     structDef.url = `${tank.config.canonical}/StructureDefinition/${structDef.id}`;
     if (fshDefinition.title) structDef.title = fshDefinition.title;
     if (fshDefinition.description) structDef.description = fshDefinition.description;
+    if (fshDefinition instanceof Profile || fshDefinition instanceof Extension) {
+      structDef.derivation = 'constraint';
+    }
   }
 
   /**

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -48,7 +48,6 @@ export class StructureDefinition {
   contextInvariant: string[];
   type: string;
   baseDefinition: string;
-  derivation: string;
 
   /**
    * The StructureDefinition's elements.  The returned array should not be pushed to directly.  Instead, use
@@ -247,6 +246,10 @@ export class StructureDefinition {
         j[prop] = cloneDeep(this[prop]);
       }
     }
+
+    // Now handle derivation
+    j.derivation = 'constraint';
+
     // Now handle snapshot and differential
     j.snapshot = { element: this.elements.map(e => e.toJSON()) };
     j.differential = {
@@ -444,6 +447,7 @@ type PathPart = {
  */
 interface LooseStructDefJSON {
   resourceType: string;
+  derivation?: string;
   snapshot?: { element: any[] };
   differential?: { element: any[] };
   // [key: string]: any;
@@ -484,6 +488,5 @@ const PROPS = [
   'context',
   'contextInvariant',
   'type',
-  'baseDefinition',
-  'derivation'
+  'baseDefinition'
 ];

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -48,6 +48,7 @@ export class StructureDefinition {
   contextInvariant: string[];
   type: string;
   baseDefinition: string;
+  derivation: 'specialization' | 'constraint';
 
   /**
    * The StructureDefinition's elements.  The returned array should not be pushed to directly.  Instead, use
@@ -246,9 +247,6 @@ export class StructureDefinition {
         j[prop] = cloneDeep(this[prop]);
       }
     }
-
-    // Now handle derivation
-    j.derivation = 'constraint';
 
     // Now handle snapshot and differential
     j.snapshot = { element: this.elements.map(e => e.toJSON()) };
@@ -488,5 +486,6 @@ const PROPS = [
   'context',
   'contextInvariant',
   'type',
-  'baseDefinition'
+  'baseDefinition',
+  'derivation'
 ];

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -41,6 +41,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.description).toBe('foo bar foobar');
     expect(exported.url).toBe('http://example.com/StructureDefinition/foo');
     expect(exported.type).toBe('Observation');
+    expect(exported.derivation).toBe('constraint');
   });
 
   it('should not overwrite metadata that is not given for a profile', () => {
@@ -53,6 +54,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.description).toBe('This is the base resource type for everything.');
     expect(exported.url).toBe('http://example.com/StructureDefinition/Foo');
     expect(exported.type).toBe('Resource');
+    expect(exported.derivation).toBe('constraint');
   });
 
   it('should throw ParentNotDefinedError when parent resource is not found', () => {
@@ -78,6 +80,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.description).toBe('foo bar foobar');
     expect(exported.url).toBe('http://example.com/StructureDefinition/foo');
     expect(exported.type).toBe('Extension');
+    expect(exported.derivation).toBe('constraint');
   });
 
   it('should not overwrite metadata that is not given for an extension', () => {
@@ -92,6 +95,7 @@ describe('StructureDefinitionExporter', () => {
     );
     expect(exported.url).toBe('http://example.com/StructureDefinition/Foo');
     expect(exported.type).toBe('Extension');
+    expect(exported.derivation).toBe('constraint');
   });
 
   it('should throw ParentNotDefinedError when parent extension is not found', () => {

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -81,6 +81,14 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.title).toBe('Foo Profile');
     expect(exported.description).toBe('foo bar foobar');
     expect(exported.url).toBe('http://example.com/StructureDefinition/foo');
+    // NOTE: For now, we always set context to everything, but this will be user-specified in
+    // the future
+    expect(exported.context).toEqual([
+      {
+        type: 'element',
+        expression: 'Element'
+      }
+    ]);
     expect(exported.type).toBe('Extension');
     expect(exported.baseDefinition).toBe('http://hl7.org/fhir/StructureDefinition/Extension');
     expect(exported.derivation).toBe('constraint');
@@ -97,9 +105,34 @@ describe('StructureDefinitionExporter', () => {
       'Base StructureDefinition for Extension Type: Optional Extension Element - found in all resources.'
     );
     expect(exported.url).toBe('http://example.com/StructureDefinition/Foo');
+    // NOTE: For now, we always set context to everything, but this will be user-specified in
+    // the future
+    expect(exported.context).toEqual([
+      {
+        type: 'element',
+        expression: 'Element'
+      }
+    ]);
     expect(exported.type).toBe('Extension');
     expect(exported.baseDefinition).toBe('http://hl7.org/fhir/StructureDefinition/Extension');
     expect(exported.derivation).toBe('constraint');
+  });
+
+  it('should not hardcode in the default context if parent already had a context', () => {
+    // NOTE: This is a temporary test to ensure that we don't overwrite a valid context with our
+    // "default" context.  In the (near) future, however, we should do away with our default
+    // context and make context user-specified, in which case it should override the parent's
+    // context.
+    const extension = new Extension('Foo');
+    extension.parent = 'http://hl7.org/fhir/StructureDefinition/patient-animal';
+    doc.extensions.set(extension.name, extension);
+    const exported = exporter.exportStructDef(extension, input);
+    expect(exported.context).toEqual([
+      {
+        type: 'element',
+        expression: 'Patient'
+      }
+    ]);
   });
 
   it('should throw ParentNotDefinedError when parent extension is not found', () => {

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -41,6 +41,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.description).toBe('foo bar foobar');
     expect(exported.url).toBe('http://example.com/StructureDefinition/foo');
     expect(exported.type).toBe('Observation');
+    expect(exported.baseDefinition).toBe('http://hl7.org/fhir/StructureDefinition/Observation');
     expect(exported.derivation).toBe('constraint');
   });
 
@@ -54,6 +55,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.description).toBe('This is the base resource type for everything.');
     expect(exported.url).toBe('http://example.com/StructureDefinition/Foo');
     expect(exported.type).toBe('Resource');
+    expect(exported.baseDefinition).toBe('http://hl7.org/fhir/StructureDefinition/Resource');
     expect(exported.derivation).toBe('constraint');
   });
 
@@ -80,6 +82,7 @@ describe('StructureDefinitionExporter', () => {
     expect(exported.description).toBe('foo bar foobar');
     expect(exported.url).toBe('http://example.com/StructureDefinition/foo');
     expect(exported.type).toBe('Extension');
+    expect(exported.baseDefinition).toBe('http://hl7.org/fhir/StructureDefinition/Extension');
     expect(exported.derivation).toBe('constraint');
   });
 
@@ -95,6 +98,7 @@ describe('StructureDefinitionExporter', () => {
     );
     expect(exported.url).toBe('http://example.com/StructureDefinition/Foo');
     expect(exported.type).toBe('Extension');
+    expect(exported.baseDefinition).toBe('http://hl7.org/fhir/StructureDefinition/Extension');
     expect(exported.derivation).toBe('constraint');
   });
 


### PR DESCRIPTION
Fixes the bug that @kjmahalingam noticed where the `derivation` needs to be set to `constraint`. Also bumps the version number in preparation for a bug fix release and updates a dependency with a security vulnerability.