### PR TITLE
Add source tracking for FSH entities

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -978,7 +978,7 @@ export class ElementDefinition {
         });
       if (!fixedToSame) {
         const found = this.patternCodeableConcept.coding[0];
-        throw new CodeAlreadyFixedError({ code: found.code, system: found.system }, code);
+        throw new CodeAlreadyFixedError(new FshCode(found.code, found.system), code);
       }
       // It's already fixed, so there is nothing to do
       return;
@@ -1009,7 +1009,7 @@ export class ElementDefinition {
     if (this.patternCoding) {
       if (this.patternCoding.code != code.code || this.patternCoding.system != code.system) {
         const found = this.patternCoding;
-        throw new CodeAlreadyFixedError({ code: found.code, system: found.system }, code);
+        throw new CodeAlreadyFixedError(new FshCode(found.code, found.system), code);
       }
       // It's already fixed, so there is nothing to do
       return;
@@ -1037,7 +1037,7 @@ export class ElementDefinition {
     if (this.patternQuantity) {
       if (this.patternQuantity.code != code.code || this.patternQuantity.system != code.system) {
         const found = this.patternQuantity;
-        throw new CodeAlreadyFixedError({ code: found.code, system: found.system }, code);
+        throw new CodeAlreadyFixedError(new FshCode(found.code, found.system), code);
       }
       // It's already fixed, so there is nothing to do
       return;
@@ -1063,7 +1063,7 @@ export class ElementDefinition {
     // Check if this is already fixed to something else
     if (this.fixedCode) {
       if (this.fixedCode != code.code) {
-        throw new CodeAlreadyFixedError({ code: this.fixedCode }, code);
+        throw new CodeAlreadyFixedError(new FshCode(this.fixedCode), code);
       }
       // It's already fixed, so there is nothing to do
       return;
@@ -1083,7 +1083,7 @@ export class ElementDefinition {
     // Check if this is already fixed to something else
     if (this.fixedString) {
       if (this.fixedString != code.code) {
-        throw new CodeAlreadyFixedError({ code: this.fixedString }, code);
+        throw new CodeAlreadyFixedError(new FshCode(this.fixedString), code);
       }
       // It's already fixed, so there is nothing to do
       return;
@@ -1103,7 +1103,7 @@ export class ElementDefinition {
     // Check if this is already fixed to something else
     if (this.fixedUri) {
       if (this.fixedUri != code.code) {
-        throw new CodeAlreadyFixedError({ code: this.fixedUri }, code);
+        throw new CodeAlreadyFixedError(new FshCode(this.fixedUri), code);
       }
       // It's already fixed, so there is nothing to do
       return;

--- a/src/fshtypes/Extension.ts
+++ b/src/fshtypes/Extension.ts
@@ -7,7 +7,13 @@ export class Extension {
   description?: string;
   rules: Rule[];
 
-  constructor(public name: string) {
+  constructor(
+    public name: string,
+    public startLine?: number,
+    public startColumn?: number,
+    public endLine?: number,
+    public endColumn?: number
+  ) {
     // Init id to be same as name.  This can be overridden using FSH syntax (Id: keyword)
     this.id = name;
     // Init the parent to 'Extension', as this is what 99% of extensions do.

--- a/src/fshtypes/Extension.ts
+++ b/src/fshtypes/Extension.ts
@@ -1,19 +1,15 @@
 import { Rule } from './rules/Rule';
+import { FshEntity } from './FshEntity';
 
-export class Extension {
+export class Extension extends FshEntity {
   id: string;
   parent: string;
   title?: string;
   description?: string;
   rules: Rule[];
 
-  constructor(
-    public name: string,
-    public startLine?: number,
-    public startColumn?: number,
-    public endLine?: number,
-    public endColumn?: number
-  ) {
+  constructor(public name: string) {
+    super();
     // Init id to be same as name.  This can be overridden using FSH syntax (Id: keyword)
     this.id = name;
     // Init the parent to 'Extension', as this is what 99% of extensions do.

--- a/src/fshtypes/FshCode.ts
+++ b/src/fshtypes/FshCode.ts
@@ -1,3 +1,7 @@
-export class FshCode {
-  constructor(public code: string, public system?: string, public display?: string) {}
+import { FshEntity } from './FshEntity';
+
+export class FshCode extends FshEntity {
+  constructor(public code: string, public system?: string, public display?: string) {
+    super();
+  }
 }

--- a/src/fshtypes/FshEntity.ts
+++ b/src/fshtypes/FshEntity.ts
@@ -1,0 +1,13 @@
+/**
+ * Abstract class to contain elements common to all FSH types.
+ */
+export abstract class FshEntity {
+  constructor(public location?: TextLocation) {}
+}
+
+export type TextLocation = {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+};

--- a/src/fshtypes/FshEntity.ts
+++ b/src/fshtypes/FshEntity.ts
@@ -2,8 +2,32 @@
  * Abstract class to contain elements common to all FSH types.
  */
 export abstract class FshEntity {
-  constructor(public location?: TextLocation) {}
+  readonly sourceInfo: SourceInfo = {};
+
+  public withLocation(location: TextLocation | [number, number, number, number]): this {
+    if (Array.isArray(location)) {
+      this.sourceInfo.location = {
+        startLine: location[0],
+        startColumn: location[1],
+        endLine: location[2],
+        endColumn: location[3]
+      };
+    } else {
+      this.sourceInfo.location = location;
+    }
+    return this;
+  }
+
+  public withFile(file: string): this {
+    this.sourceInfo.file = file;
+    return this;
+  }
 }
+
+export type SourceInfo = {
+  file?: string;
+  location?: TextLocation;
+};
 
 export type TextLocation = {
   startLine: number;

--- a/src/fshtypes/FshQuantity.ts
+++ b/src/fshtypes/FshQuantity.ts
@@ -1,7 +1,10 @@
 import { FshCode } from './FshCode';
+import { FshEntity } from './FshEntity';
 
-export class FshQuantity {
-  constructor(public value: number, public unit?: FshCode) {}
+export class FshQuantity extends FshEntity {
+  constructor(public value: number, public unit?: FshCode) {
+    super();
+  }
 
   toString() {
     let str = this.value.toString();

--- a/src/fshtypes/FshRatio.ts
+++ b/src/fshtypes/FshRatio.ts
@@ -1,7 +1,10 @@
 import { FshQuantity } from './FshQuantity';
+import { FshEntity } from './FshEntity';
 
-export class FshRatio {
-  constructor(public numerator: FshQuantity, public denominator: FshQuantity) {}
+export class FshRatio extends FshEntity {
+  constructor(public numerator: FshQuantity, public denominator: FshQuantity) {
+    super();
+  }
 
   toString() {
     return `${this.numerator.toString()} : ${this.denominator.toString()}`;

--- a/src/fshtypes/Instance.ts
+++ b/src/fshtypes/Instance.ts
@@ -1,11 +1,13 @@
 import { Rule } from './rules/Rule';
+import { FshEntity } from './FshEntity';
 
-export class Instance {
+export class Instance extends FshEntity {
   id: string;
   instanceOf: string;
   rules: Rule[];
 
   constructor(public name: string) {
+    super();
     this.id = name; // init same as name
     this.rules = [];
   }

--- a/src/fshtypes/Profile.ts
+++ b/src/fshtypes/Profile.ts
@@ -1,19 +1,15 @@
 import { Rule } from './rules/Rule';
+import { FshEntity } from './FshEntity';
 
-export class Profile {
+export class Profile extends FshEntity {
   id: string;
   parent?: string;
   title?: string;
   description?: string;
   rules: Rule[];
 
-  constructor(
-    public name: string,
-    public startLine?: number,
-    public startColumn?: number,
-    public endLine?: number,
-    public endColumn?: number
-  ) {
+  constructor(public name: string) {
+    super();
     this.id = name; // init same as name
     this.rules = [];
   }

--- a/src/fshtypes/Profile.ts
+++ b/src/fshtypes/Profile.ts
@@ -7,7 +7,13 @@ export class Profile {
   description?: string;
   rules: Rule[];
 
-  constructor(public name: string) {
+  constructor(
+    public name: string,
+    public startLine?: number,
+    public startColumn?: number,
+    public endLine?: number,
+    public endColumn?: number
+  ) {
     this.id = name; // init same as name
     this.rules = [];
   }

--- a/src/fshtypes/index.ts
+++ b/src/fshtypes/index.ts
@@ -4,3 +4,4 @@ export * from './Instance';
 export * from './Profile';
 export * from './FshQuantity';
 export * from './FshRatio';
+export * from './FshEntity';

--- a/src/fshtypes/rules/Rule.ts
+++ b/src/fshtypes/rules/Rule.ts
@@ -1,3 +1,7 @@
-export class Rule {
-  constructor(public path: string) {}
+import { FshEntity } from '../FshEntity';
+
+export class Rule extends FshEntity {
+  constructor(public path: string) {
+    super();
+  }
 }

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -86,7 +86,13 @@ export class FSHImporter extends FSHVisitor {
   }
 
   visitProfile(ctx: pc.ProfileContext) {
-    const profile = new Profile(ctx.SEQUENCE().getText());
+    const profile = new Profile(
+      ctx.SEQUENCE().getText(),
+      ctx.start.line,
+      ctx.start.start,
+      ctx.stop.line,
+      ctx.stop.stop - ctx.stop.start + ctx.stop.column + 1
+    );
     this.parseProfileOrExtension(profile, ctx.sdMetadata(), ctx.sdRule());
     this.doc.profiles.set(profile.name, profile);
   }

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -86,25 +86,13 @@ export class FSHImporter extends FSHVisitor {
   }
 
   visitProfile(ctx: pc.ProfileContext) {
-    const profile = new Profile(
-      ctx.SEQUENCE().getText(),
-      ctx.start.line,
-      ctx.start.start,
-      ctx.stop.line,
-      ctx.stop.stop - ctx.stop.start + ctx.stop.column + 1
-    );
+    const profile = new Profile(ctx.SEQUENCE().getText(), ...this.extractStartStop(ctx));
     this.parseProfileOrExtension(profile, ctx.sdMetadata(), ctx.sdRule());
     this.doc.profiles.set(profile.name, profile);
   }
 
   visitExtension(ctx: pc.ExtensionContext) {
-    const extension = new Extension(
-      ctx.SEQUENCE().getText(),
-      ctx.start.line,
-      ctx.start.start,
-      ctx.stop.line,
-      ctx.stop.stop - ctx.stop.start + ctx.stop.column + 1
-    );
+    const extension = new Extension(ctx.SEQUENCE().getText(), ...this.extractStartStop(ctx));
     this.parseProfileOrExtension(extension, ctx.sdMetadata(), ctx.sdRule());
     this.doc.extensions.set(extension.name, extension);
   }
@@ -419,5 +407,14 @@ export class FSHImporter extends FSHVisitor {
 
     // consistently remove the common leading spaces and join the lines back together
     return lines.map(l => (l.length >= minSpaces ? l.slice(minSpaces) : l)).join('\n');
+  }
+
+  private extractStartStop(ctx: ParserRuleContext): [number, number, number, number] {
+    return [
+      ctx.start.line,
+      ctx.start.start,
+      ctx.stop.line,
+      ctx.stop.stop - ctx.stop.start + ctx.stop.column + 1
+    ];
   }
 }

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -98,7 +98,13 @@ export class FSHImporter extends FSHVisitor {
   }
 
   visitExtension(ctx: pc.ExtensionContext) {
-    const extension = new Extension(ctx.SEQUENCE().getText());
+    const extension = new Extension(
+      ctx.SEQUENCE().getText(),
+      ctx.start.line,
+      ctx.start.start,
+      ctx.stop.line,
+      ctx.stop.stop - ctx.stop.start + ctx.stop.column + 1
+    );
     this.parseProfileOrExtension(extension, ctx.sdMetadata(), ctx.sdRule());
     this.doc.extensions.set(extension.name, extension);
   }

--- a/test/fhirtypes/ElementDefinition.fixFshCode.test.ts
+++ b/test/fhirtypes/ElementDefinition.fixFshCode.test.ts
@@ -17,8 +17,8 @@ describe('ElementDefinition', () => {
   });
   beforeEach(() => {
     observation = StructureDefinition.fromJSON(jsonObservation);
-    fooBarCode = { code: 'bar', system: 'http://foo.com' };
-    barFooCode = { code: 'foo', system: 'http://bar.com' };
+    fooBarCode = new FshCode('bar', 'http://foo.com');
+    barFooCode = new FshCode('foo', 'http://bar.com');
   });
 
   describe('#fixFshCode()', () => {

--- a/test/import/FSHImporter.Extension.test.ts
+++ b/test/import/FSHImporter.Extension.test.ts
@@ -22,6 +22,10 @@ describe('FSHImporter', () => {
         expect(extension.parent).toBe('Extension');
         // if no id is explicitly set, should default to name
         expect(extension.id).toBe('SomeExtension');
+        expect(extension.startLine).toBe(2);
+        expect(extension.startColumn).toBe(9);
+        expect(extension.endLine).toBe(2);
+        expect(extension.endColumn).toBe(32);
       });
 
       it('should parse profile with additional metadata properties', () => {
@@ -41,6 +45,10 @@ describe('FSHImporter', () => {
         expect(extension.id).toBe('some-extension');
         expect(extension.title).toBe('Some Extension');
         expect(extension.description).toBe('An extension on something');
+        expect(extension.startLine).toBe(2);
+        expect(extension.startColumn).toBe(9);
+        expect(extension.endLine).toBe(6);
+        expect(extension.endColumn).toBe(48);
       });
     });
 

--- a/test/import/FSHImporter.Extension.test.ts
+++ b/test/import/FSHImporter.Extension.test.ts
@@ -22,10 +22,12 @@ describe('FSHImporter', () => {
         expect(extension.parent).toBe('Extension');
         // if no id is explicitly set, should default to name
         expect(extension.id).toBe('SomeExtension');
-        expect(extension.location.startLine).toBe(2);
-        expect(extension.location.startColumn).toBe(9);
-        expect(extension.location.endLine).toBe(2);
-        expect(extension.location.endColumn).toBe(32);
+        expect(extension.sourceInfo.location).toEqual({
+          startLine: 2,
+          startColumn: 9,
+          endLine: 2,
+          endColumn: 32
+        });
       });
 
       it('should parse profile with additional metadata properties', () => {
@@ -45,10 +47,12 @@ describe('FSHImporter', () => {
         expect(extension.id).toBe('some-extension');
         expect(extension.title).toBe('Some Extension');
         expect(extension.description).toBe('An extension on something');
-        expect(extension.location.startLine).toBe(2);
-        expect(extension.location.startColumn).toBe(9);
-        expect(extension.location.endLine).toBe(6);
-        expect(extension.location.endColumn).toBe(48);
+        expect(extension.sourceInfo.location).toEqual({
+          startLine: 2,
+          startColumn: 9,
+          endLine: 6,
+          endColumn: 48
+        });
       });
     });
 

--- a/test/import/FSHImporter.Extension.test.ts
+++ b/test/import/FSHImporter.Extension.test.ts
@@ -22,10 +22,10 @@ describe('FSHImporter', () => {
         expect(extension.parent).toBe('Extension');
         // if no id is explicitly set, should default to name
         expect(extension.id).toBe('SomeExtension');
-        expect(extension.startLine).toBe(2);
-        expect(extension.startColumn).toBe(9);
-        expect(extension.endLine).toBe(2);
-        expect(extension.endColumn).toBe(32);
+        expect(extension.location.startLine).toBe(2);
+        expect(extension.location.startColumn).toBe(9);
+        expect(extension.location.endLine).toBe(2);
+        expect(extension.location.endColumn).toBe(32);
       });
 
       it('should parse profile with additional metadata properties', () => {
@@ -45,10 +45,10 @@ describe('FSHImporter', () => {
         expect(extension.id).toBe('some-extension');
         expect(extension.title).toBe('Some Extension');
         expect(extension.description).toBe('An extension on something');
-        expect(extension.startLine).toBe(2);
-        expect(extension.startColumn).toBe(9);
-        expect(extension.endLine).toBe(6);
-        expect(extension.endColumn).toBe(48);
+        expect(extension.location.startLine).toBe(2);
+        expect(extension.location.startColumn).toBe(9);
+        expect(extension.location.endLine).toBe(6);
+        expect(extension.location.endColumn).toBe(48);
       });
     });
 

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -24,6 +24,10 @@ describe('FSHImporter', () => {
         expect(profile.parent).toBe('Observation');
         // if no id is explicitly set, should default to name
         expect(profile.id).toBe('ObservationProfile');
+        expect(profile.startLine).toBe(2);
+        expect(profile.startColumn).toBe(9);
+        expect(profile.endLine).toBe(3);
+        expect(profile.endColumn).toBe(27);
       });
 
       it('should parse profile with additional metadata properties', () => {
@@ -43,6 +47,10 @@ describe('FSHImporter', () => {
         expect(profile.id).toBe('observation-profile');
         expect(profile.title).toBe('An Observation Profile');
         expect(profile.description).toBe('A profile on Observation');
+        expect(profile.startLine).toBe(2);
+        expect(profile.startColumn).toBe(9);
+        expect(profile.endLine).toBe(6);
+        expect(profile.endColumn).toBe(47);
       });
 
       it('should properly parse a multi-string description', () => {

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -24,10 +24,10 @@ describe('FSHImporter', () => {
         expect(profile.parent).toBe('Observation');
         // if no id is explicitly set, should default to name
         expect(profile.id).toBe('ObservationProfile');
-        expect(profile.startLine).toBe(2);
-        expect(profile.startColumn).toBe(9);
-        expect(profile.endLine).toBe(3);
-        expect(profile.endColumn).toBe(27);
+        expect(profile.location.startLine).toBe(2);
+        expect(profile.location.startColumn).toBe(9);
+        expect(profile.location.endLine).toBe(3);
+        expect(profile.location.endColumn).toBe(27);
       });
 
       it('should parse profile with additional metadata properties', () => {
@@ -47,10 +47,10 @@ describe('FSHImporter', () => {
         expect(profile.id).toBe('observation-profile');
         expect(profile.title).toBe('An Observation Profile');
         expect(profile.description).toBe('A profile on Observation');
-        expect(profile.startLine).toBe(2);
-        expect(profile.startColumn).toBe(9);
-        expect(profile.endLine).toBe(6);
-        expect(profile.endColumn).toBe(47);
+        expect(profile.location.startLine).toBe(2);
+        expect(profile.location.startColumn).toBe(9);
+        expect(profile.location.endLine).toBe(6);
+        expect(profile.location.endColumn).toBe(47);
       });
 
       it('should properly parse a multi-string description', () => {
@@ -459,7 +459,14 @@ describe('FSHImporter', () => {
         const result = importText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
-        assertFixedValueRule(profile.rules[0], 'status', new FshCode('final'));
+        const expectedCode = new FshCode('final');
+        expectedCode.location = {
+          startLine: 6,
+          startColumn: 20,
+          endLine: 6,
+          endColumn: 25
+        };
+        assertFixedValueRule(profile.rules[0], 'status', expectedCode);
       });
 
       it('should parse fixed value CodeableConcept rule', () => {
@@ -474,11 +481,18 @@ describe('FSHImporter', () => {
         const result = importText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
-        assertFixedValueRule(
-          profile.rules[0],
-          'valueCodeableConcept',
-          new FshCode('718-7', 'http://loinc.org', 'Hemoglobin [Mass/volume] in Blood')
+        const expectedCode = new FshCode(
+          '718-7',
+          'http://loinc.org',
+          'Hemoglobin [Mass/volume] in Blood'
         );
+        expectedCode.location = {
+          startLine: 6,
+          startColumn: 34,
+          endLine: 6,
+          endColumn: 80
+        };
+        assertFixedValueRule(profile.rules[0], 'valueCodeableConcept', expectedCode);
       });
 
       it('should parse fixed value Quantity rule', () => {
@@ -492,11 +506,23 @@ describe('FSHImporter', () => {
         const result = importText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
-        assertFixedValueRule(
-          profile.rules[0],
-          'valueQuantity',
-          new FshQuantity(1.5, new FshCode('mm', 'http://unitsofmeasure.org'))
+        const expectedQuantity = new FshQuantity(
+          1.5,
+          new FshCode('mm', 'http://unitsofmeasure.org')
         );
+        expectedQuantity.location = {
+          startLine: 5,
+          startColumn: 27,
+          endLine: 5,
+          endColumn: 34
+        };
+        expectedQuantity.unit.location = {
+          startLine: 5,
+          startColumn: 31,
+          endLine: 5,
+          endColumn: 34
+        };
+        assertFixedValueRule(profile.rules[0], 'valueQuantity', expectedQuantity);
       });
 
       it('should parse fixed value Ratio rule', () => {
@@ -510,14 +536,41 @@ describe('FSHImporter', () => {
         const result = importText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
-        assertFixedValueRule(
-          profile.rules[0],
-          'valueRatio',
-          new FshRatio(
-            new FshQuantity(130, new FshCode('mg', 'http://unitsofmeasure.org')),
-            new FshQuantity(1, new FshCode('dL', 'http://unitsofmeasure.org'))
-          )
+        const expectedRatio = new FshRatio(
+          new FshQuantity(130, new FshCode('mg', 'http://unitsofmeasure.org')),
+          new FshQuantity(1, new FshCode('dL', 'http://unitsofmeasure.org'))
         );
+        expectedRatio.location = {
+          startLine: 5,
+          startColumn: 24,
+          endLine: 5,
+          endColumn: 40
+        };
+        expectedRatio.numerator.location = {
+          startLine: 5,
+          startColumn: 24,
+          endLine: 5,
+          endColumn: 31
+        };
+        expectedRatio.numerator.unit.location = {
+          startLine: 5,
+          startColumn: 28,
+          endLine: 5,
+          endColumn: 31
+        };
+        expectedRatio.denominator.location = {
+          startLine: 5,
+          startColumn: 35,
+          endLine: 5,
+          endColumn: 40
+        };
+        expectedRatio.denominator.unit.location = {
+          startLine: 5,
+          startColumn: 37,
+          endLine: 5,
+          endColumn: 40
+        };
+        assertFixedValueRule(profile.rules[0], 'valueRatio', expectedRatio);
       });
 
       it('should parse fixed value Ratio rule w/ numeric numerator', () => {
@@ -531,14 +584,35 @@ describe('FSHImporter', () => {
         const result = importText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
-        assertFixedValueRule(
-          profile.rules[0],
-          'valueRatio',
-          new FshRatio(
-            new FshQuantity(130),
-            new FshQuantity(1, new FshCode('dL', 'http://unitsofmeasure.org'))
-          )
+        const expectedRatio = new FshRatio(
+          new FshQuantity(130),
+          new FshQuantity(1, new FshCode('dL', 'http://unitsofmeasure.org'))
         );
+        expectedRatio.location = {
+          startLine: 5,
+          startColumn: 24,
+          endLine: 5,
+          endColumn: 35
+        };
+        expectedRatio.numerator.location = {
+          startLine: 5,
+          startColumn: 24,
+          endLine: 5,
+          endColumn: 26
+        };
+        expectedRatio.denominator.location = {
+          startLine: 5,
+          startColumn: 30,
+          endLine: 5,
+          endColumn: 35
+        };
+        expectedRatio.denominator.unit.location = {
+          startLine: 5,
+          startColumn: 32,
+          endLine: 5,
+          endColumn: 35
+        };
+        assertFixedValueRule(profile.rules[0], 'valueRatio', expectedRatio);
       });
 
       it('should parse fixed value Ratio rule w/ numeric denominator', () => {
@@ -552,14 +626,35 @@ describe('FSHImporter', () => {
         const result = importText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
-        assertFixedValueRule(
-          profile.rules[0],
-          'valueRatio',
-          new FshRatio(
-            new FshQuantity(130, new FshCode('mg', 'http://unitsofmeasure.org')),
-            new FshQuantity(1)
-          )
+        const expectedRatio = new FshRatio(
+          new FshQuantity(130, new FshCode('mg', 'http://unitsofmeasure.org')),
+          new FshQuantity(1)
         );
+        expectedRatio.location = {
+          startLine: 5,
+          startColumn: 24,
+          endLine: 5,
+          endColumn: 35
+        };
+        expectedRatio.numerator.location = {
+          startLine: 5,
+          startColumn: 24,
+          endLine: 5,
+          endColumn: 31
+        };
+        expectedRatio.numerator.unit.location = {
+          startLine: 5,
+          startColumn: 28,
+          endLine: 5,
+          endColumn: 31
+        };
+        expectedRatio.denominator.location = {
+          startLine: 5,
+          startColumn: 35,
+          endLine: 5,
+          endColumn: 35
+        };
+        assertFixedValueRule(profile.rules[0], 'valueRatio', expectedRatio);
       });
 
       it('should parse fixed value Ratio rule w/ numeric numerator and denominator', () => {
@@ -573,11 +668,26 @@ describe('FSHImporter', () => {
         const result = importText(input);
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(1);
-        assertFixedValueRule(
-          profile.rules[0],
-          'valueRatio',
-          new FshRatio(new FshQuantity(130), new FshQuantity(1))
-        );
+        const expectedRatio = new FshRatio(new FshQuantity(130), new FshQuantity(1));
+        expectedRatio.location = {
+          startLine: 5,
+          startColumn: 24,
+          endLine: 5,
+          endColumn: 30
+        };
+        expectedRatio.numerator.location = {
+          startLine: 5,
+          startColumn: 24,
+          endLine: 5,
+          endColumn: 26
+        };
+        expectedRatio.denominator.location = {
+          startLine: 5,
+          startColumn: 30,
+          endLine: 5,
+          endColumn: 30
+        };
+        assertFixedValueRule(profile.rules[0], 'valueRatio', expectedRatio);
       });
     });
 


### PR DESCRIPTION
Since most of the FSH types can have a direct location in the text, the `FSHEntity` class is created to serve as a parent to contain that location information. Right now, that's all it has, but if there are any other parsing-related attributes that need to be tracked, they can be placed in `FSHEntity`.

Tests involving the classes that now track location information are updated in order to satisfy deep equality when comparing with the assert methods.

This pull request addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-126