### PR TITLE
Import contains rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ pids
 logs
 results
 tmp
-out
+/out*
 
 # Build
 public/css/main.css

--- a/src/fshtypes/rules/ContainsRule.ts
+++ b/src/fshtypes/rules/ContainsRule.ts
@@ -1,0 +1,10 @@
+import { Rule } from './Rule';
+
+export class ContainsRule extends Rule {
+  sliceNames: string[];
+
+  constructor(path: string) {
+    super(path);
+    this.sliceNames = [];
+  }
+}

--- a/src/fshtypes/rules/ContainsRule.ts
+++ b/src/fshtypes/rules/ContainsRule.ts
@@ -1,10 +1,10 @@
 import { Rule } from './Rule';
 
 export class ContainsRule extends Rule {
-  sliceNames: string[];
+  items: string[];
 
   constructor(path: string) {
     super(path);
-    this.sliceNames = [];
+    this.items = [];
   }
 }

--- a/src/fshtypes/rules/index.ts
+++ b/src/fshtypes/rules/index.ts
@@ -4,3 +4,4 @@ export * from './FlagRule';
 export * from './OnlyRule';
 export * from './Rule';
 export * from './ValueSetRule';
+export * from './ContainsRule';

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -403,17 +403,17 @@ export class FSHImporter extends FSHVisitor {
 
     rules.push(containsRule);
     ctx.item().forEach(i => {
-      const sliceName = i.SEQUENCE().getText();
-      containsRule.sliceNames.push(sliceName);
+      const item = this.aliasAwareValue(i.SEQUENCE().getText());
+      containsRule.items.push(item);
 
-      const cardRule = new CardRule(`${containsRule.path}[${sliceName}]`);
+      const cardRule = new CardRule(`${containsRule.path}[${item}]`);
       const card = this.parseCard(i.CARD().getText());
       cardRule.min = card.min;
       cardRule.max = card.max;
       rules.push(cardRule);
 
       if (i.flag() && i.flag().length > 0) {
-        const flagRule = new FlagRule(`${containsRule.path}[${sliceName}]`);
+        const flagRule = new FlagRule(`${containsRule.path}[${item}]`);
         this.parseFlags(flagRule, i.flag());
         rules.push(flagRule);
       }

--- a/src/import/parserContexts.ts
+++ b/src/import/parserContexts.ts
@@ -56,7 +56,7 @@ export interface SdRuleContext extends ParserRuleContext {
   flagRule(): FlagRuleContext;
   valueSetRule(): ValueSetRuleContext;
   fixedValueRule(): FixedValueRuleContext;
-  // containsRule(): ContainsRuleContext;
+  containsRule(): ContainsRuleContext;
   onlyRule(): OnlyRuleContext;
   // obeysRule(): ObeysRuleContext;
   // caretValueRule(): CaretValueRuleContext;
@@ -140,6 +140,17 @@ export interface RatioPartContext extends ParserRuleContext {
 export interface BoolContext extends ParserRuleContext {
   KW_TRUE(): ParserRuleContext;
   KW_FALSE(): ParserRuleContext;
+}
+
+export interface ContainsRuleContext extends ParserRuleContext {
+  path(): PathContext;
+  item(): ItemContext[];
+}
+
+export interface ItemContext extends ParserRuleContext {
+  SEQUENCE(): ParserRuleContext;
+  CARD(): ParserRuleContext;
+  flag(): FlagContext[];
 }
 
 export interface OnlyRuleContext extends ParserRuleContext {

--- a/test/fshtypes/rules/ContainsRule.test.ts
+++ b/test/fshtypes/rules/ContainsRule.test.ts
@@ -6,7 +6,7 @@ describe('ContainsRule', () => {
     it('should set the properties correctly', () => {
       const c = new ContainsRule('component.code');
       expect(c.path).toBe('component.code');
-      expect(c.sliceNames.length).toBe(0);
+      expect(c.items.length).toBe(0);
     });
   });
 });

--- a/test/fshtypes/rules/ContainsRule.test.ts
+++ b/test/fshtypes/rules/ContainsRule.test.ts
@@ -1,0 +1,12 @@
+import 'jest-extended';
+import { ContainsRule } from '../../../src/fshtypes/rules/ContainsRule';
+
+describe('ContainsRule', () => {
+  describe('#constructor', () => {
+    it('should set the properties correctly', () => {
+      const c = new ContainsRule('component.code');
+      expect(c.path).toBe('component.code');
+      expect(c.sliceNames.length).toBe(0);
+    });
+  });
+});

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -716,6 +716,21 @@ describe('FSHImporter', () => {
       assertCardRule(profile.rules[1], 'component[SystolicBP]', 1, 1);
     });
 
+    it('should parse contains rule with an alias', () => {
+      const input = `
+      Alias: FooBar = http://example.com
+      Profile: ObservationProfile
+      Parent: Observation
+      * component contains FooBar 1..1
+      `;
+
+      const result = importText(input);
+      const profile = result.profiles.get('ObservationProfile');
+      expect(profile.rules).toHaveLength(2);
+      assertContainsRule(profile.rules[0], 'component', 'http://example.com');
+      assertCardRule(profile.rules[1], 'component[http://example.com]', 1, 1);
+    });
+
     it('should parse contains rules with multiple types', () => {
       const input = `
       Profile: ObservationProfile

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -3,7 +3,8 @@ import {
   assertFixedValueRule,
   assertFlagRule,
   assertOnlyRule,
-  assertValueSetRule
+  assertValueSetRule,
+  assertContainsRule
 } from '../utils/asserts';
 import { importText } from '../../src/import';
 import { FshCode, FshQuantity, FshRatio } from '../../src/fshtypes';
@@ -697,6 +698,54 @@ describe('FSHImporter', () => {
           { type: 'http://hl7.org/fhir/StructureDefinition/Quantity' }
         );
       });
+    });
+  });
+
+  describe('#containsRule', () => {
+    it('should parse contains rule with one type', () => {
+      const input = `
+      Profile: ObservationProfile
+      Parent: Observation
+      * component contains SystolicBP 1..1
+      `;
+
+      const result = importText(input);
+      const profile = result.profiles.get('ObservationProfile');
+      expect(profile.rules).toHaveLength(2);
+      assertContainsRule(profile.rules[0], 'component', 'SystolicBP');
+      assertCardRule(profile.rules[1], 'component[SystolicBP]', 1, 1);
+    });
+
+    it('should parse contains rules with multiple types', () => {
+      const input = `
+      Profile: ObservationProfile
+      Parent: Observation
+      * component contains SystolicBP 1..1 and DiastolicBP 2..*
+      `;
+
+      const result = importText(input);
+      const profile = result.profiles.get('ObservationProfile');
+      expect(profile.rules).toHaveLength(3);
+      assertContainsRule(profile.rules[0], 'component', 'SystolicBP', 'DiastolicBP');
+      assertCardRule(profile.rules[1], 'component[SystolicBP]', 1, 1);
+      assertCardRule(profile.rules[2], 'component[DiastolicBP]', 2, '*');
+    });
+
+    it('should parse contains rules with flags', () => {
+      const input = `
+      Profile: ObservationProfile
+      Parent: Observation
+      * component contains SystolicBP 1..1 MS and DiastolicBP 2..* MS SU
+      `;
+
+      const result = importText(input);
+      const profile = result.profiles.get('ObservationProfile');
+      expect(profile.rules).toHaveLength(5);
+      assertContainsRule(profile.rules[0], 'component', 'SystolicBP', 'DiastolicBP');
+      assertCardRule(profile.rules[1], 'component[SystolicBP]', 1, 1);
+      assertFlagRule(profile.rules[2], 'component[SystolicBP]', true, undefined, undefined);
+      assertCardRule(profile.rules[3], 'component[DiastolicBP]', 2, '*');
+      assertFlagRule(profile.rules[4], 'component[DiastolicBP]', true, true, undefined);
     });
   });
 });

--- a/test/utils/asserts.ts
+++ b/test/utils/asserts.ts
@@ -60,10 +60,10 @@ export function assertOnlyRule(rule: Rule, path: string, ...types: OnlyRuleType[
   expect(onlyRule.types).toEqual(types);
 }
 
-export function assertContainsRule(rule: Rule, path: string, ...sliceNames: string[]): void {
+export function assertContainsRule(rule: Rule, path: string, ...items: string[]): void {
   expect(rule).toBeInstanceOf(ContainsRule);
   const containsRule = rule as ContainsRule;
   expect(containsRule.path).toBe(path);
 
-  expect(containsRule.sliceNames).toEqual(sliceNames);
+  expect(containsRule.items).toEqual(items);
 }

--- a/test/utils/asserts.ts
+++ b/test/utils/asserts.ts
@@ -6,7 +6,8 @@ import {
   FixedValueRule,
   FixedValueType,
   OnlyRule,
-  OnlyRuleType
+  OnlyRuleType,
+  ContainsRule
 } from '../../src/fshtypes/rules';
 
 export function assertCardRule(rule: Rule, path: string, min: number, max: number | string): void {
@@ -57,4 +58,12 @@ export function assertOnlyRule(rule: Rule, path: string, ...types: OnlyRuleType[
   const onlyRule = rule as OnlyRule;
   expect(onlyRule.path).toBe(path);
   expect(onlyRule.types).toEqual(types);
+}
+
+export function assertContainsRule(rule: Rule, path: string, ...sliceNames: string[]): void {
+  expect(rule).toBeInstanceOf(ContainsRule);
+  const containsRule = rule as ContainsRule;
+  expect(containsRule.path).toBe(path);
+
+  expect(containsRule.sliceNames).toEqual(sliceNames);
 }


### PR DESCRIPTION
This adds a `ContainsRule` class that stores information for constraints that use the `contains` keyword https://github.com/HL7/fhir-shorthand/wiki/2.4-Constraints. It also adds logic to the importer that will use the `ContainsRule` class to store information when the `contains` keyword is used on a `Profile` or an `Extension`, and it adds tests of this functionality.

This also update `.gitignore` so that any directory starting with `out` is ignored. I was running the cli a few times and this became an issue for me.