### PR TITLE
Set Instance Property

### DIFF
--- a/src/errors/CannotResolvePathError.ts
+++ b/src/errors/CannotResolvePathError.ts
@@ -1,0 +1,5 @@
+export class CannotResolvePathError extends Error {
+  constructor(public path: string) {
+    super(`Cannot resolve path ${path} to an element`);
+  }
+}

--- a/src/errors/CannotResolvePathError.ts
+++ b/src/errors/CannotResolvePathError.ts
@@ -1,5 +1,5 @@
 export class CannotResolvePathError extends Error {
   constructor(public path: string) {
-    super(`Cannot resolve path ${path} to an element`);
+    super(`Cannot resolve element from path: ${path}`);
   }
 }

--- a/src/errors/InvalidElementAccessError.ts
+++ b/src/errors/InvalidElementAccessError.ts
@@ -1,0 +1,7 @@
+export class InvalidElementAccessError extends Error {
+  constructor(public path: string) {
+    super(
+      `Cannot directly access differential or snapshot with path: ${path}. Elements should be targeted for modification by their path.`
+    );
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -17,3 +17,4 @@ export * from './SlicingNotDefinedError';
 export * from './TypeNotFoundError';
 export * from './UnitMismatchError';
 export * from './WideningCardinalityError';
+export * from './CannotResolvePathError';

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -18,3 +18,4 @@ export * from './TypeNotFoundError';
 export * from './UnitMismatchError';
 export * from './WideningCardinalityError';
 export * from './CannotResolvePathError';
+export * from './InvalidElementAccessError';

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -5,6 +5,7 @@ import { FHIRDefinitions } from '../../src/fhirdefs/FHIRDefinitions';
 import { StructureDefinition } from '../../src/fhirtypes/StructureDefinition';
 import { ElementDefinition } from '../../src/fhirtypes/ElementDefinition';
 import { getResolver } from '../utils/getResolver';
+import { FshCode } from '../../src/fshtypes';
 
 describe('StructureDefinition', () => {
   let defs: FHIRDefinitions;
@@ -259,6 +260,102 @@ describe('StructureDefinition', () => {
     });
   });
 
+  describe('#setInstancePropertyByPath', () => {
+    let jsonObservation: any;
+    let jsonStructureDefinition: any;
+    let observation: StructureDefinition;
+    let structureDefinition: StructureDefinition;
+    beforeAll(() => {
+      jsonObservation = defs.findResource('Observation');
+      jsonStructureDefinition = defs.findResource('StructureDefinition');
+    });
+    beforeEach(() => {
+      structureDefinition = StructureDefinition.fromJSON(jsonStructureDefinition);
+      observation = StructureDefinition.fromJSON(jsonObservation, structureDefinition);
+    });
+
+    it('should set an instance property which has a value', () => {
+      observation.setInstancePropertyByPath('version', '1.2.3', getResolver(defs));
+      expect(observation.version).toBe('1.2.3');
+    });
+
+    it('should set an instance property which must be created', () => {
+      observation.setInstancePropertyByPath('contextInvariant', 'foo', getResolver(defs));
+      expect(observation.contextInvariant).toBe('foo');
+    });
+
+    it('should not an instance property which is being fixed incorrectly', () => {
+      expect(() => {
+        observation.setInstancePropertyByPath('version', 1.2, getResolver(defs));
+      }).toThrow('Cannot fix number value: 1.2. Value does not match element type: string');
+      expect(observation.version).toBe('4.0.1');
+    });
+
+    it('should add an instance property in an array', () => {
+      observation.setInstancePropertyByPath(
+        'contact[2].telecom[0].value',
+        'foo',
+        getResolver(defs)
+      );
+      expect(observation.contact.length).toBe(3);
+      expect(observation.contact[2]).toEqual({ telecom: [{ value: 'foo' }] });
+    });
+
+    it('should add an instance property to an array element that has some value', () => {
+      observation.setInstancePropertyByPath(
+        'contact[0].telecom[0].period.start',
+        '2019-11-25',
+        getResolver(defs)
+      );
+      expect(observation.contact.length).toBe(2);
+      expect(observation.contact[0]).toEqual({
+        telecom: [{ value: 'http://hl7.org/fhir', system: 'url', period: { start: '2019-11-25' } }]
+      });
+    });
+
+    it('should add an instance property in an array that must be empty filled', () => {
+      observation.setInstancePropertyByPath(
+        'contact[4].telecom[0].value',
+        'foo',
+        getResolver(defs)
+      );
+      expect(observation.contact.length).toBe(5);
+      expect(observation.contact[4]).toEqual({ telecom: [{ value: 'foo' }] });
+      expect(observation.contact[3]).toEqual({});
+      expect(observation.contact[2]).toEqual({});
+    });
+
+    it('should change an instance property in an array', () => {
+      observation.setInstancePropertyByPath(
+        'contact[1].telecom[0].value',
+        'foo',
+        getResolver(defs)
+      );
+      expect(observation.contact.length).toBe(2);
+      expect(observation.contact[1]).toEqual({ telecom: [{ value: 'foo', system: 'url' }] });
+    });
+
+    it('should not add an instance property in an array with invalid index', () => {
+      observation.setInstancePropertyByPath(
+        'contact[-1].telecom[0].value',
+        'foo',
+        getResolver(defs)
+      );
+      expect(observation.contact.length).toBe(2);
+    });
+
+    it('should set a complex instance property on a newly created array', () => {
+      observation.setInstancePropertyByPath(
+        'jurisdiction[0]',
+        new FshCode('foo', 'http://example.com')
+      );
+      expect(observation.jurisdiction.length).toBe(1);
+      expect(observation.jurisdiction[0]).toEqual({
+        coding: [{ code: 'foo', system: 'http://example.com' }]
+      });
+    });
+  });
+
   describe('#canFixValue', () => {
     let jsonStructureDefinition: any;
     let jsonRespRate: any;
@@ -278,15 +375,19 @@ describe('StructureDefinition', () => {
     });
 
     it('should allow fixing an instance value', () => {
-      expect(structureDefinition.canFixValue('version', '4.0.2')).toBe(true);
+      expect(structureDefinition.canFixValue('version', '4.0.2')).toBe('4.0.2');
     });
 
     it('should not allow fixing an instance value with an incorrect path', () => {
-      expect(structureDefinition.canFixValue('Version', '4.0.2')).toBe(false);
+      expect(() => {
+        structureDefinition.canFixValue('Version', '4.0.2');
+      }).toThrow('Cannot resolve path Version to an element');
     });
 
     it('should not allow fixing an instance value with an incorrect value', () => {
-      expect(structureDefinition.canFixValue('version', true)).toBe(false);
+      expect(() => {
+        structureDefinition.canFixValue('version', true);
+      }).toThrow('Cannot fix boolean value: true. Value does not match element type: string');
     });
 
     it('should not allow fixing an instance value with a 0 cardinality', () => {
@@ -294,31 +395,33 @@ describe('StructureDefinition', () => {
         e => e.id === 'StructureDefinition.version'
       );
       version.max = '0';
-      expect(structureDefinition.canFixValue('version', '4.0.2')).toBe(false);
+      expect(() => {
+        structureDefinition.canFixValue('version', '4.0.2');
+      }).toThrow('Cannot resolve path version to an element');
     });
 
     it('should allow fixing an instance value to an element in an array', () => {
       expect(structureDefinition.canFixValue('identifier[0].value', 'foo', getResolver(defs))).toBe(
-        true
+        'foo'
       );
     });
 
     it('should not allow using array brackets when an element is not an array', () => {
-      const identifier = structureDefinition.elements.find(
-        e => e.id === 'StructureDefinition.identifier'
-      );
-      identifier.max = '0';
-      expect(structureDefinition.canFixValue('identifier[0].value', 'foo', getResolver(defs))).toBe(
-        false
-      );
+      expect(() => {
+        structureDefinition.canFixValue('version[0]', 'foo', getResolver(defs));
+      }).toThrow('Cannot resolve path version[0] to an element');
     });
 
     it('should allow fixing an instance value on a slice', () => {
-      expect(respRate.canFixValue('category[VSCat].coding.version', 'foo')).toBe(true);
+      expect(respRate.canFixValue('category[VSCat].coding.version', 'foo', getResolver(defs))).toBe(
+        'foo'
+      );
     });
 
     it('should allow fixing an instance value on a slice array', () => {
-      expect(CSSPC.canFixValue('extension[required][3].value[x]', 'foo')).toBe(true);
+      expect(CSSPC.canFixValue('extension[required][3].value[x]', 'foo', getResolver(defs))).toBe(
+        'foo'
+      );
     });
   });
 


### PR DESCRIPTION
This addresses CIMPL-98, https://standardhealthrecord.atlassian.net/browse/CIMPL-98, by implementing `StructureDefinition.setInstancePropertyByFshPath`. This will be used with the `^` syntax to directly set attributes on a `StructureDefinition` when making a profile, as described here https://github.com/HL7/fhir-shorthand/wiki/2.2-Paths#addressing-structure-definition-attributes-directly.

The overall approach is to get a path, and then check if that path is valid using the FHIR StructureDefinition of the StructureDefinition resource. This is done by the `validateValueAtPath` function. This function will also add implied 0 indices to the path, meaning that if we have a path `foo.bar`, and `foo` is an array, that path is treated as `foo[0].bar`. If the path is valid, we set the value at that path on our `StructureDefinition` class.