### PR TITLE
Add support for FSHy Parents

### DIFF
--- a/src/export/ExtensionExporter.ts
+++ b/src/export/ExtensionExporter.ts
@@ -5,20 +5,19 @@ import { FHIRDefinitions } from '../fhirdefs';
 import { logger } from '../utils/FSHLogger';
 
 export class ExtensionExporter extends StructureDefinitionExporter {
-  constructor(FHIRDefs: FHIRDefinitions) {
-    super(FHIRDefs);
+  constructor(FHIRDefs: FHIRDefinitions, tank: FSHTank) {
+    super(FHIRDefs, tank);
   }
 
   /**
    * Exports Extensions to StructureDefinitions
-   * @param {FSHTank} tank - The FSH tank we are exporting
    * @returns {StructureDefinition[]}
    */
-  export(tank: FSHTank): StructureDefinition[] {
-    for (const doc of tank.docs) {
+  export(): StructureDefinition[] {
+    for (const doc of this.tank.docs) {
       for (const extension of doc.extensions.values()) {
         try {
-          this.exportStructDef(extension, tank);
+          this.exportStructDef(extension);
         } catch (e) {
           logger.error(e.message);
         }

--- a/src/export/ExtensionExporter.ts
+++ b/src/export/ExtensionExporter.ts
@@ -18,7 +18,7 @@ export class ExtensionExporter extends StructureDefinitionExporter {
     for (const doc of tank.docs) {
       for (const extension of doc.extensions.values()) {
         try {
-          const structDef = this.exportStructDef(extension, tank);
+          this.exportStructDef(extension, tank);
         } catch (e) {
           logger.error(e.message);
         }

--- a/src/export/ExtensionExporter.ts
+++ b/src/export/ExtensionExporter.ts
@@ -15,17 +15,16 @@ export class ExtensionExporter extends StructureDefinitionExporter {
    * @returns {StructureDefinition[]}
    */
   export(tank: FSHTank): StructureDefinition[] {
-    const structDefs: StructureDefinition[] = [];
     for (const doc of tank.docs) {
       for (const extension of doc.extensions.values()) {
         try {
           const structDef = this.exportStructDef(extension, tank);
-          structDefs.push(structDef);
+          this.structDefs.push(structDef);
         } catch (e) {
           logger.error(e.message);
         }
       }
     }
-    return structDefs;
+    return this.structDefs;
   }
 }

--- a/src/export/ExtensionExporter.ts
+++ b/src/export/ExtensionExporter.ts
@@ -19,7 +19,6 @@ export class ExtensionExporter extends StructureDefinitionExporter {
       for (const extension of doc.extensions.values()) {
         try {
           const structDef = this.exportStructDef(extension, tank);
-          this.structDefs.push(structDef);
         } catch (e) {
           logger.error(e.message);
         }

--- a/src/export/ExtensionExporter.ts
+++ b/src/export/ExtensionExporter.ts
@@ -14,13 +14,11 @@ export class ExtensionExporter extends StructureDefinitionExporter {
    * @returns {StructureDefinition[]}
    */
   export(): StructureDefinition[] {
-    for (const doc of this.tank.docs) {
-      for (const extension of doc.extensions.values()) {
-        try {
-          this.exportStructDef(extension);
-        } catch (e) {
-          logger.error(e.message);
-        }
+    for (const extension of this.tank.getAllExtensions()) {
+      try {
+        this.exportStructDef(extension);
+      } catch (e) {
+        logger.error(e.message);
       }
     }
     return this.structDefs;

--- a/src/export/FHIRExporter.ts
+++ b/src/export/FHIRExporter.ts
@@ -2,25 +2,26 @@ import { FSHTank } from '../import/FSHTank';
 import { Package } from './Package';
 import { ProfileExporter } from './ProfileExporter';
 import { ExtensionExporter } from './ExtensionExporter';
-import { load } from '../fhirdefs';
+import { load, FHIRDefinitions } from '../fhirdefs';
 /**
  * FHIRExporter handles the processing of FSH documents, storing the FSH types within them as FHIR types.
  * FHIRExporter takes the Profiles and Extensions within the FSHDocuments of a FSHTank and returns them
  * as a structured Package.
  */
 export class FHIRExporter {
-  private readonly profileExporter: ProfileExporter;
-  private readonly extensionExporter: ExtensionExporter;
+  private readonly FHIRDefs: FHIRDefinitions;
+  private profileExporter: ProfileExporter;
+  private extensionExporter: ExtensionExporter;
 
   constructor() {
-    const FHIRDefs = load('4.0.1');
-    this.profileExporter = new ProfileExporter(FHIRDefs);
-    this.extensionExporter = new ExtensionExporter(FHIRDefs);
+    this.FHIRDefs = load('4.0.1');
   }
 
   export(tank: FSHTank): Package {
-    const profileDefs = this.profileExporter.export(tank);
-    const extensionDefs = this.extensionExporter.export(tank);
+    this.profileExporter = new ProfileExporter(this.FHIRDefs, tank);
+    this.extensionExporter = new ExtensionExporter(this.FHIRDefs, tank);
+    const profileDefs = this.profileExporter.export();
+    const extensionDefs = this.extensionExporter.export();
     return new Package(profileDefs, extensionDefs, tank.config);
   }
 }

--- a/src/export/ProfileExporter.ts
+++ b/src/export/ProfileExporter.ts
@@ -15,17 +15,16 @@ export class ProfileExporter extends StructureDefinitionExporter {
    * @returns {StructureDefinition[]}
    */
   export(tank: FSHTank): StructureDefinition[] {
-    const structDefs: StructureDefinition[] = [];
     for (const doc of tank.docs) {
       for (const profile of doc.profiles.values()) {
         try {
           const structDef = this.exportStructDef(profile, tank);
-          structDefs.push(structDef);
+          this.structDefs.push(structDef);
         } catch (e) {
           logger.error(e.message);
         }
       }
     }
-    return structDefs;
+    return this.structDefs;
   }
 }

--- a/src/export/ProfileExporter.ts
+++ b/src/export/ProfileExporter.ts
@@ -5,20 +5,19 @@ import { FHIRDefinitions } from '../fhirdefs';
 import { logger } from '../utils/FSHLogger';
 
 export class ProfileExporter extends StructureDefinitionExporter {
-  constructor(FHIRDefs: FHIRDefinitions) {
-    super(FHIRDefs);
+  constructor(FHIRDefs: FHIRDefinitions, tank: FSHTank) {
+    super(FHIRDefs, tank);
   }
 
   /**
    * Exports Profiles to StructureDefinitions
-   * @param {FSHTank} tank - The FSH tank we are exporting
    * @returns {StructureDefinition[]}
    */
-  export(tank: FSHTank): StructureDefinition[] {
-    for (const doc of tank.docs) {
+  export(): StructureDefinition[] {
+    for (const doc of this.tank.docs) {
       for (const profile of doc.profiles.values()) {
         try {
-          this.exportStructDef(profile, tank);
+          this.exportStructDef(profile);
         } catch (e) {
           logger.error(e.message);
         }

--- a/src/export/ProfileExporter.ts
+++ b/src/export/ProfileExporter.ts
@@ -18,8 +18,7 @@ export class ProfileExporter extends StructureDefinitionExporter {
     for (const doc of tank.docs) {
       for (const profile of doc.profiles.values()) {
         try {
-          const structDef = this.exportStructDef(profile, tank);
-          this.structDefs.push(structDef);
+          this.exportStructDef(profile, tank);
         } catch (e) {
           logger.error(e.message);
         }

--- a/src/export/ProfileExporter.ts
+++ b/src/export/ProfileExporter.ts
@@ -14,13 +14,11 @@ export class ProfileExporter extends StructureDefinitionExporter {
    * @returns {StructureDefinition[]}
    */
   export(): StructureDefinition[] {
-    for (const doc of this.tank.docs) {
-      for (const profile of doc.profiles.values()) {
-        try {
-          this.exportStructDef(profile);
-        } catch (e) {
-          logger.error(e.message);
-        }
+    for (const profile of this.tank.getAllProfiles()) {
+      try {
+        this.exportStructDef(profile);
+      } catch (e) {
+        logger.error(e.message);
       }
     }
     return this.structDefs;

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -5,7 +5,7 @@ import { FSHTank } from '../import';
 import { ParentNotDefinedError } from '../errors/ParentNotDefinedError';
 import { CardRule, FixedValueRule, FlagRule, OnlyRule, ValueSetRule } from '../fshtypes/rules';
 import { logger } from '../utils/FSHLogger';
-import { cloneDeep, flatMap } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 /**
  * The StructureDefinitionExporter is a parent class for ProfileExporter and ExtensionExporter.
@@ -115,11 +115,9 @@ export class StructureDefinitionExporter {
       let parentDefinition: Profile | Extension;
       // Our parent will be of the same type as the current definition
       if (fshDefinition instanceof Profile) {
-        const profiles = flatMap(this.tank.docs, doc => Array.from(doc.profiles.values()));
-        parentDefinition = profiles.find(profile => profile.name === parentName);
+        parentDefinition = this.tank.findProfileByName(parentName);
       } else if (fshDefinition instanceof Extension) {
-        const extensions = flatMap(this.tank.docs, doc => Array.from(doc.extensions.values()));
-        parentDefinition = extensions.find(extension => extension.name === parentName);
+        parentDefinition = this.tank.findExtensionByName(parentName);
       }
 
       // If we found a parent, then we can export and resolve for its type again

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -96,6 +96,11 @@ export class StructureDefinitionExporter {
     const json = this.FHIRDefs.find(type);
     if (json) {
       return StructureDefinition.fromJSON(json);
+    } else {
+      const structDef = this.structDefs.find(sd => sd.name === type);
+      if (structDef) {
+        return structDef;
+      }
     }
   }
 

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -114,6 +114,10 @@ export class StructureDefinitionExporter {
    * @returns {StructureDefinition}
    */
   exportStructDef(fshDefinition: Profile | Extension): void {
+    if (this.structDefs.some(sd => sd.name === fshDefinition.name)) {
+      return;
+    }
+
     const parentName = fshDefinition.parent || 'Resource';
     const structDef = this.resolve(parentName);
 
@@ -127,8 +131,6 @@ export class StructureDefinitionExporter {
     this.setMetadata(structDef, fshDefinition);
     this.setRules(structDef, fshDefinition);
 
-    if (!this.structDefs.some(sd => sd.name === structDef.name)) {
-      this.structDefs.push(structDef);
-    }
+    this.structDefs.push(structDef);
   }
 }

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -97,7 +97,7 @@ export class StructureDefinitionExporter {
     const json = this.FHIRDefs.find(type);
     if (json) {
       return StructureDefinition.fromJSON(json);
-    // Maybe it's a FSH-defined definition and not a FHIR one
+      // Maybe it's a FSH-defined definition and not a FHIR one
     } else {
       const structDef = cloneDeep(this.structDefs.find(sd => sd.name === type));
       if (structDef) {
@@ -112,7 +112,7 @@ export class StructureDefinitionExporter {
    * @param {FSHTank} tank - The FSH tank we are exporting
    * @returns {StructureDefinition}
    */
-  exportStructDef(fshDefinition: Profile | Extension, tank: FSHTank): StructureDefinition {
+  exportStructDef(fshDefinition: Profile | Extension, tank: FSHTank): void {
     const parentName = fshDefinition.parent || 'Resource';
     let structDef = this.resolve(parentName);
 
@@ -145,10 +145,8 @@ export class StructureDefinitionExporter {
     this.setMetadata(structDef, fshDefinition, tank);
     this.setRules(structDef, fshDefinition);
 
-    // Push the structure definition to the exporter's array of them, and return as well
     if (!this.structDefs.some(sd => sd.name === structDef.name)) {
       this.structDefs.push(structDef);
     }
-    return structDef;
   }
 }

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -12,6 +12,8 @@ import { logger } from '../utils/FSHLogger';
  * between the two should be included in this class.
  */
 export class StructureDefinitionExporter {
+  public readonly structDefs: StructureDefinition[] = [];
+
   constructor(public readonly FHIRDefs: FHIRDefinitions) {}
 
   /**
@@ -105,11 +107,8 @@ export class StructureDefinitionExporter {
    */
   exportStructDef(fshDefinition: Profile | Extension, tank: FSHTank): StructureDefinition {
     const parentName = fshDefinition.parent || 'Resource';
-    const jsonParent = this.FHIRDefs.find(parentName);
-    let structDef: StructureDefinition;
-    if (jsonParent) {
-      structDef = StructureDefinition.fromJSON(jsonParent);
-    } else {
+    const structDef = this.resolve(parentName);
+    if (!structDef) {
       throw new ParentNotDefinedError(fshDefinition.name, parentName);
     }
     // Capture the orginal elements so that any further changes are reflected in the differential

--- a/src/import/FSHTank.ts
+++ b/src/import/FSHTank.ts
@@ -1,5 +1,41 @@
 import { FSHDocument } from './FSHDocument';
+import { Profile, Extension } from '../fshtypes';
+import flatMap from 'lodash/flatMap';
 
 export class FSHTank {
   constructor(public readonly docs: FSHDocument[], public readonly config: any) {}
+
+  /**
+   * Gets all profiles in the tank
+   * @returns {Profile[]}
+   */
+  public getAllProfiles(): Profile[] {
+    return flatMap(this.docs, doc => Array.from(doc.profiles.values()));
+  }
+
+  /**
+   * Gets all extensions in the tank
+   * @returns {Extension[]}
+   */
+  public getAllExtensions(): Extension[] {
+    return flatMap(this.docs, doc => Array.from(doc.extensions.values()));
+  }
+
+  /**
+   * Finds the profile in the tank by name, if it exists
+   * @param {string} name - The name of the profile we're looking for
+   * @returns {Profile | undefined}
+   */
+  public findProfileByName(name: string): Profile | undefined {
+    return this.getAllProfiles().find(profile => profile.name === name);
+  }
+
+  /**
+   * Finds the extension in the tank by name, if it exists
+   * @param {string} name - The name of the extension we're looking for
+   * @returns {Extension | undefined}
+   */
+  public findExtensionByName(name: string): Extension | undefined {
+    return this.getAllExtensions().find(extension => extension.name === name);
+  }
 }

--- a/test/export/ExtensionExporter.test.ts
+++ b/test/export/ExtensionExporter.test.ts
@@ -51,10 +51,20 @@ describe('ExtensionExporter', () => {
     expect(exported[0].name).toBe('Bar');
   });
 
-  it('should export extensions with other extensions as parents', () => {
+  it('should export extensions with other extensions as parents in order', () => {
     const extensionFoo = new Extension('Foo');
     const extensionBar = new Extension('Bar');
     extensionBar.parent = 'Foo';
+    doc.extensions.set(extensionFoo.name, extensionFoo);
+    doc.extensions.set(extensionBar.name, extensionBar);
+    const exported = exporter.export(input);
+    expect(exported.length).toBe(2);
+  });
+
+  it('should export extensions with other extensions as parents out of order', () => {
+    const extensionFoo = new Extension('Foo');
+    extensionFoo.parent = 'Bar';
+    const extensionBar = new Extension('Bar');
     doc.extensions.set(extensionFoo.name, extensionFoo);
     doc.extensions.set(extensionBar.name, extensionBar);
     const exported = exporter.export(input);

--- a/test/export/ExtensionExporter.test.ts
+++ b/test/export/ExtensionExporter.test.ts
@@ -61,6 +61,7 @@ describe('ExtensionExporter', () => {
     expect(exported.length).toBe(2);
     expect(exported[0].name).toBe('Foo');
     expect(exported[1].name).toBe('Bar');
+    expect(exported[1].baseDefinition === exported[0].url);
   });
 
   it('should export extensions with the same FSHy parents', () => {
@@ -77,6 +78,8 @@ describe('ExtensionExporter', () => {
     expect(exported[0].name).toBe('Foo');
     expect(exported[1].name).toBe('Bar');
     expect(exported[2].name).toBe('Baz');
+    expect(exported[1].baseDefinition === exported[0].url);
+    expect(exported[2].baseDefinition === exported[0].url);
   });
 
   it('should export extensions with deep FSHy parents', () => {
@@ -93,6 +96,8 @@ describe('ExtensionExporter', () => {
     expect(exported[0].name).toBe('Foo');
     expect(exported[1].name).toBe('Bar');
     expect(exported[2].name).toBe('Baz');
+    expect(exported[1].baseDefinition === exported[0].url);
+    expect(exported[2].baseDefinition === exported[1].url);
   });
 
   it('should export extensions with out-of-order FSHy parents', () => {
@@ -109,5 +114,7 @@ describe('ExtensionExporter', () => {
     expect(exported[0].name).toBe('Baz');
     expect(exported[1].name).toBe('Bar');
     expect(exported[2].name).toBe('Foo');
+    expect(exported[1].baseDefinition === exported[0].url);
+    expect(exported[2].baseDefinition === exported[1].url);
   });
 });

--- a/test/export/ExtensionExporter.test.ts
+++ b/test/export/ExtensionExporter.test.ts
@@ -51,7 +51,7 @@ describe('ExtensionExporter', () => {
     expect(exported[0].name).toBe('Bar');
   });
 
-  it('should export extensions with other extensions as parents in order', () => {
+  it('should export extensions with FSHy parents', () => {
     const extensionFoo = new Extension('Foo');
     const extensionBar = new Extension('Bar');
     extensionBar.parent = 'Foo';
@@ -59,15 +59,55 @@ describe('ExtensionExporter', () => {
     doc.extensions.set(extensionBar.name, extensionBar);
     const exported = exporter.export(input);
     expect(exported.length).toBe(2);
+    expect(exported[0].name).toBe('Foo');
+    expect(exported[1].name).toBe('Bar');
   });
 
-  it('should export extensions with other extensions as parents out of order', () => {
+  it('should export extensions with the same FSHy parents', () => {
+    const extensionFoo = new Extension('Foo');
+    const extensionBar = new Extension('Bar');
+    extensionBar.parent = 'Foo';
+    const extensionBaz = new Extension('Baz');
+    extensionBaz.parent = 'Foo';
+    doc.extensions.set(extensionFoo.name, extensionFoo);
+    doc.extensions.set(extensionBar.name, extensionBar);
+    doc.extensions.set(extensionBaz.name, extensionBaz);
+    const exported = exporter.export(input);
+    expect(exported.length).toBe(3);
+    expect(exported[0].name).toBe('Foo');
+    expect(exported[1].name).toBe('Bar');
+    expect(exported[2].name).toBe('Baz');
+  });
+
+  it('should export extensions with deep FSHy parents', () => {
+    const extensionFoo = new Extension('Foo');
+    const extensionBar = new Extension('Bar');
+    extensionBar.parent = 'Foo';
+    const extensionBaz = new Extension('Baz');
+    extensionBaz.parent = 'Bar';
+    doc.extensions.set(extensionFoo.name, extensionFoo);
+    doc.extensions.set(extensionBar.name, extensionBar);
+    doc.extensions.set(extensionBaz.name, extensionBaz);
+    const exported = exporter.export(input);
+    expect(exported.length).toBe(3);
+    expect(exported[0].name).toBe('Foo');
+    expect(exported[1].name).toBe('Bar');
+    expect(exported[2].name).toBe('Baz');
+  });
+
+  it('should export extensions with out-of-order FSHy parents', () => {
     const extensionFoo = new Extension('Foo');
     extensionFoo.parent = 'Bar';
     const extensionBar = new Extension('Bar');
+    extensionBar.parent = 'Baz';
+    const extensionBaz = new Extension('Baz');
     doc.extensions.set(extensionFoo.name, extensionFoo);
     doc.extensions.set(extensionBar.name, extensionBar);
+    doc.extensions.set(extensionBaz.name, extensionBaz);
     const exported = exporter.export(input);
-    expect(exported.length).toBe(2);
+    expect(exported.length).toBe(3);
+    expect(exported[0].name).toBe('Baz');
+    expect(exported[1].name).toBe('Bar');
+    expect(exported[2].name).toBe('Foo');
   });
 });

--- a/test/export/ExtensionExporter.test.ts
+++ b/test/export/ExtensionExporter.test.ts
@@ -50,4 +50,14 @@ describe('ExtensionExporter', () => {
     expect(exported.length).toBe(1);
     expect(exported[0].name).toBe('Bar');
   });
+
+  it('should export extensions with other extensions as parents', () => {
+    const extensionFoo = new Extension('Foo');
+    const extensionBar = new Extension('Bar');
+    extensionBar.parent = 'Foo';
+    doc.extensions.set(extensionFoo.name, extensionFoo);
+    doc.extensions.set(extensionBar.name, extensionBar);
+    const exported = exporter.export(input);
+    expect(exported.length).toBe(2);
+  });
 });

--- a/test/export/ExtensionExporter.test.ts
+++ b/test/export/ExtensionExporter.test.ts
@@ -16,18 +16,18 @@ describe('ExtensionExporter', () => {
   beforeEach(() => {
     doc = new FSHDocument('fileName');
     input = new FSHTank([doc], { canonical: 'http://example.com' });
-    exporter = new ExtensionExporter(defs);
+    exporter = new ExtensionExporter(defs, input);
   });
 
   it('should output empty results with empty input', () => {
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported).toEqual([]);
   });
 
   it('should export a single extension', () => {
     const extension = new Extension('Foo');
     doc.extensions.set(extension.name, extension);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(1);
   });
 
@@ -36,7 +36,7 @@ describe('ExtensionExporter', () => {
     const extensionBar = new Extension('Bar');
     doc.extensions.set(extensionFoo.name, extensionFoo);
     doc.extensions.set(extensionBar.name, extensionBar);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(2);
   });
 
@@ -46,7 +46,7 @@ describe('ExtensionExporter', () => {
     const extensionBar = new Extension('Bar');
     doc.extensions.set(extensionFoo.name, extensionFoo);
     doc.extensions.set(extensionBar.name, extensionBar);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(1);
     expect(exported[0].name).toBe('Bar');
   });
@@ -57,7 +57,7 @@ describe('ExtensionExporter', () => {
     extensionBar.parent = 'Foo';
     doc.extensions.set(extensionFoo.name, extensionFoo);
     doc.extensions.set(extensionBar.name, extensionBar);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(2);
     expect(exported[0].name).toBe('Foo');
     expect(exported[1].name).toBe('Bar');
@@ -73,7 +73,7 @@ describe('ExtensionExporter', () => {
     doc.extensions.set(extensionFoo.name, extensionFoo);
     doc.extensions.set(extensionBar.name, extensionBar);
     doc.extensions.set(extensionBaz.name, extensionBaz);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(3);
     expect(exported[0].name).toBe('Foo');
     expect(exported[1].name).toBe('Bar');
@@ -91,7 +91,7 @@ describe('ExtensionExporter', () => {
     doc.extensions.set(extensionFoo.name, extensionFoo);
     doc.extensions.set(extensionBar.name, extensionBar);
     doc.extensions.set(extensionBaz.name, extensionBaz);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(3);
     expect(exported[0].name).toBe('Foo');
     expect(exported[1].name).toBe('Bar');
@@ -109,7 +109,7 @@ describe('ExtensionExporter', () => {
     doc.extensions.set(extensionFoo.name, extensionFoo);
     doc.extensions.set(extensionBar.name, extensionBar);
     doc.extensions.set(extensionBaz.name, extensionBaz);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(3);
     expect(exported[0].name).toBe('Baz');
     expect(exported[1].name).toBe('Bar');

--- a/test/export/ProfileExporter.test.ts
+++ b/test/export/ProfileExporter.test.ts
@@ -51,7 +51,7 @@ describe('ProfileExporter', () => {
     expect(exported[0].name).toBe('Bar');
   });
 
-  it('should export profiles with other profiles as parents in order', () => {
+  it('should export profiles with FSHy parents', () => {
     const profileFoo = new Profile('Foo');
     const profileBar = new Profile('Bar');
     profileBar.parent = 'Foo';
@@ -59,15 +59,55 @@ describe('ProfileExporter', () => {
     doc.profiles.set(profileBar.name, profileBar);
     const exported = exporter.export(input);
     expect(exported.length).toBe(2);
+    expect(exported[0].name).toBe('Foo');
+    expect(exported[1].name).toBe('Bar');
   });
 
-  it('should export profiles with other profiles as parents out of order', () => {
+  it('should export profiles with the same FSHy parents', () => {
+    const profileFoo = new Profile('Foo');
+    const profileBar = new Profile('Bar');
+    profileBar.parent = 'Foo';
+    const profileBaz = new Profile('Baz');
+    profileBaz.parent = 'Foo';
+    doc.profiles.set(profileFoo.name, profileFoo);
+    doc.profiles.set(profileBar.name, profileBar);
+    doc.profiles.set(profileBaz.name, profileBaz);
+    const exported = exporter.export(input);
+    expect(exported.length).toBe(3);
+    expect(exported[0].name).toBe('Foo');
+    expect(exported[1].name).toBe('Bar');
+    expect(exported[2].name).toBe('Baz');
+  });
+
+  it('should export profiles with deep FSHy parents', () => {
+    const profileFoo = new Profile('Foo');
+    const profileBar = new Profile('Bar');
+    profileBar.parent = 'Foo';
+    const profileBaz = new Profile('Baz');
+    profileBaz.parent = 'Bar';
+    doc.profiles.set(profileFoo.name, profileFoo);
+    doc.profiles.set(profileBar.name, profileBar);
+    doc.profiles.set(profileBaz.name, profileBaz);
+    const exported = exporter.export(input);
+    expect(exported.length).toBe(3);
+    expect(exported[0].name).toBe('Foo');
+    expect(exported[1].name).toBe('Bar');
+    expect(exported[2].name).toBe('Baz');
+  });
+
+  it('should export profiles with out-of-order FSHy parents', () => {
     const profileFoo = new Profile('Foo');
     profileFoo.parent = 'Bar';
     const profileBar = new Profile('Bar');
+    profileBar.parent = 'Baz';
+    const profileBaz = new Profile('Baz');
     doc.profiles.set(profileFoo.name, profileFoo);
     doc.profiles.set(profileBar.name, profileBar);
+    doc.profiles.set(profileBaz.name, profileBaz);
     const exported = exporter.export(input);
-    expect(exported.length).toBe(2);
+    expect(exported.length).toBe(3);
+    expect(exported[0].name).toBe('Baz');
+    expect(exported[1].name).toBe('Bar');
+    expect(exported[2].name).toBe('Foo');
   });
 });

--- a/test/export/ProfileExporter.test.ts
+++ b/test/export/ProfileExporter.test.ts
@@ -61,6 +61,7 @@ describe('ProfileExporter', () => {
     expect(exported.length).toBe(2);
     expect(exported[0].name).toBe('Foo');
     expect(exported[1].name).toBe('Bar');
+    expect(exported[1].baseDefinition === exported[0].url);
   });
 
   it('should export profiles with the same FSHy parents', () => {
@@ -77,6 +78,8 @@ describe('ProfileExporter', () => {
     expect(exported[0].name).toBe('Foo');
     expect(exported[1].name).toBe('Bar');
     expect(exported[2].name).toBe('Baz');
+    expect(exported[1].baseDefinition === exported[0].url);
+    expect(exported[2].baseDefinition === exported[0].url);
   });
 
   it('should export profiles with deep FSHy parents', () => {
@@ -93,6 +96,8 @@ describe('ProfileExporter', () => {
     expect(exported[0].name).toBe('Foo');
     expect(exported[1].name).toBe('Bar');
     expect(exported[2].name).toBe('Baz');
+    expect(exported[1].baseDefinition === exported[0].url);
+    expect(exported[2].baseDefinition === exported[1].url);
   });
 
   it('should export profiles with out-of-order FSHy parents', () => {
@@ -109,5 +114,7 @@ describe('ProfileExporter', () => {
     expect(exported[0].name).toBe('Baz');
     expect(exported[1].name).toBe('Bar');
     expect(exported[2].name).toBe('Foo');
+    expect(exported[1].baseDefinition === exported[0].url);
+    expect(exported[2].baseDefinition === exported[1].url);
   });
 });

--- a/test/export/ProfileExporter.test.ts
+++ b/test/export/ProfileExporter.test.ts
@@ -16,18 +16,18 @@ describe('ProfileExporter', () => {
   beforeEach(() => {
     doc = new FSHDocument('fileName');
     input = new FSHTank([doc], { canonical: 'http://example.com' });
-    exporter = new ProfileExporter(defs);
+    exporter = new ProfileExporter(defs, input);
   });
 
   it('should output empty results with empty input', () => {
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported).toEqual([]);
   });
 
   it('should export a single profile', () => {
     const profile = new Profile('Foo');
     doc.profiles.set(profile.name, profile);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(1);
   });
 
@@ -36,7 +36,7 @@ describe('ProfileExporter', () => {
     const profileBar = new Profile('Bar');
     doc.profiles.set(profileFoo.name, profileFoo);
     doc.profiles.set(profileBar.name, profileBar);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(2);
   });
 
@@ -46,7 +46,7 @@ describe('ProfileExporter', () => {
     const profileBar = new Profile('Bar');
     doc.profiles.set(profileFoo.name, profileFoo);
     doc.profiles.set(profileBar.name, profileBar);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(1);
     expect(exported[0].name).toBe('Bar');
   });
@@ -57,7 +57,7 @@ describe('ProfileExporter', () => {
     profileBar.parent = 'Foo';
     doc.profiles.set(profileFoo.name, profileFoo);
     doc.profiles.set(profileBar.name, profileBar);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(2);
     expect(exported[0].name).toBe('Foo');
     expect(exported[1].name).toBe('Bar');
@@ -73,7 +73,7 @@ describe('ProfileExporter', () => {
     doc.profiles.set(profileFoo.name, profileFoo);
     doc.profiles.set(profileBar.name, profileBar);
     doc.profiles.set(profileBaz.name, profileBaz);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(3);
     expect(exported[0].name).toBe('Foo');
     expect(exported[1].name).toBe('Bar');
@@ -91,7 +91,7 @@ describe('ProfileExporter', () => {
     doc.profiles.set(profileFoo.name, profileFoo);
     doc.profiles.set(profileBar.name, profileBar);
     doc.profiles.set(profileBaz.name, profileBaz);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(3);
     expect(exported[0].name).toBe('Foo');
     expect(exported[1].name).toBe('Bar');
@@ -109,7 +109,7 @@ describe('ProfileExporter', () => {
     doc.profiles.set(profileFoo.name, profileFoo);
     doc.profiles.set(profileBar.name, profileBar);
     doc.profiles.set(profileBaz.name, profileBaz);
-    const exported = exporter.export(input);
+    const exported = exporter.export();
     expect(exported.length).toBe(3);
     expect(exported[0].name).toBe('Baz');
     expect(exported[1].name).toBe('Bar');

--- a/test/export/ProfileExporter.test.ts
+++ b/test/export/ProfileExporter.test.ts
@@ -50,4 +50,14 @@ describe('ProfileExporter', () => {
     expect(exported.length).toBe(1);
     expect(exported[0].name).toBe('Bar');
   });
+
+  it('should export profiles with other profiles as parents', () => {
+    const profileFoo = new Profile('Foo');
+    const profileBar = new Profile('Bar');
+    profileBar.parent = 'Foo';
+    doc.profiles.set(profileFoo.name, profileFoo);
+    doc.profiles.set(profileBar.name, profileBar);
+    const exported = exporter.export(input);
+    expect(exported.length).toBe(2);
+  });
 });

--- a/test/export/ProfileExporter.test.ts
+++ b/test/export/ProfileExporter.test.ts
@@ -51,10 +51,20 @@ describe('ProfileExporter', () => {
     expect(exported[0].name).toBe('Bar');
   });
 
-  it('should export profiles with other profiles as parents', () => {
+  it('should export profiles with other profiles as parents in order', () => {
     const profileFoo = new Profile('Foo');
     const profileBar = new Profile('Bar');
     profileBar.parent = 'Foo';
+    doc.profiles.set(profileFoo.name, profileFoo);
+    doc.profiles.set(profileBar.name, profileBar);
+    const exported = exporter.export(input);
+    expect(exported.length).toBe(2);
+  });
+
+  it('should export profiles with other profiles as parents out of order', () => {
+    const profileFoo = new Profile('Foo');
+    profileFoo.parent = 'Bar';
+    const profileBar = new Profile('Bar');
     doc.profiles.set(profileFoo.name, profileFoo);
     doc.profiles.set(profileBar.name, profileBar);
     const exported = exporter.export(input);

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -23,7 +23,7 @@ describe('StructureDefinitionExporter', () => {
   beforeEach(() => {
     doc = new FSHDocument('fileName');
     input = new FSHTank([doc], { canonical: 'http://example.com' });
-    exporter = new StructureDefinitionExporter(defs);
+    exporter = new StructureDefinitionExporter(defs, input);
   });
 
   // Profile
@@ -34,7 +34,7 @@ describe('StructureDefinitionExporter', () => {
     profile.title = 'Foo Profile';
     profile.description = 'foo bar foobar';
     doc.profiles.set(profile.name, profile);
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const exported = exporter.structDefs[0];
     expect(exported.name).toBe('Foo');
     expect(exported.id).toBe('foo');
@@ -49,7 +49,7 @@ describe('StructureDefinitionExporter', () => {
   it('should not overwrite metadata that is not given for a profile', () => {
     const profile = new Profile('Foo');
     doc.profiles.set(profile.name, profile);
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const exported = exporter.structDefs[0];
     expect(exported.name).toBe('Foo');
     expect(exported.id).toBe('Foo');
@@ -66,7 +66,7 @@ describe('StructureDefinitionExporter', () => {
     profile.parent = 'Bar';
     doc.profiles.set(profile.name, profile);
     expect(() => {
-      exporter.exportStructDef(profile, input);
+      exporter.exportStructDef(profile);
     }).toThrow('Parent Bar not found for Foo');
   });
 
@@ -77,7 +77,7 @@ describe('StructureDefinitionExporter', () => {
     extension.title = 'Foo Profile';
     extension.description = 'foo bar foobar';
     doc.extensions.set(extension.name, extension);
-    exporter.exportStructDef(extension, input);
+    exporter.exportStructDef(extension);
     const exported = exporter.structDefs[0];
     expect(exported.name).toBe('Foo');
     expect(exported.id).toBe('foo');
@@ -100,7 +100,7 @@ describe('StructureDefinitionExporter', () => {
   it('should not overwrite metadata that is not given for an extension', () => {
     const extension = new Extension('Foo');
     doc.extensions.set(extension.name, extension);
-    exporter.exportStructDef(extension, input);
+    exporter.exportStructDef(extension);
     const exported = exporter.structDefs[0];
     expect(exported.name).toBe('Foo');
     expect(exported.id).toBe('Foo');
@@ -130,7 +130,7 @@ describe('StructureDefinitionExporter', () => {
     const extension = new Extension('Foo');
     extension.parent = 'http://hl7.org/fhir/StructureDefinition/patient-animal';
     doc.extensions.set(extension.name, extension);
-    exporter.exportStructDef(extension, input);
+    exporter.exportStructDef(extension);
     const exported = exporter.structDefs[0];
     expect(exported.context).toEqual([
       {
@@ -145,7 +145,7 @@ describe('StructureDefinitionExporter', () => {
     extension.parent = 'Bar';
     doc.extensions.set(extension.name, extension);
     expect(() => {
-      exporter.exportStructDef(extension, input);
+      exporter.exportStructDef(extension);
     }).toThrow('Parent Bar not found for Foo');
   });
 
@@ -157,7 +157,7 @@ describe('StructureDefinitionExporter', () => {
     rule.min = 0;
     rule.max = '1';
     profile.rules.push(rule);
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const structDef = exporter.structDefs[0];
     expect(structDef).toBeDefined();
     expect(structDef.type).toBe('Resource');
@@ -173,7 +173,7 @@ describe('StructureDefinitionExporter', () => {
     rule.max = '1';
     profile.rules.push(rule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
@@ -196,7 +196,7 @@ describe('StructureDefinitionExporter', () => {
     rule.max = '1';
     profile.rules.push(rule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
@@ -219,7 +219,7 @@ describe('StructureDefinitionExporter', () => {
     rule.mustSupport = true;
     profile.rules.push(rule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
@@ -242,7 +242,7 @@ describe('StructureDefinitionExporter', () => {
     rule.mustSupport = true;
     profile.rules.push(rule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
@@ -264,7 +264,7 @@ describe('StructureDefinitionExporter', () => {
     rule.mustSupport = false;
     profile.rules.push(rule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
@@ -288,7 +288,7 @@ describe('StructureDefinitionExporter', () => {
     vsRule.strength = 'extensible';
     profile.rules.push(vsRule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
     const baseElement = baseStructDef.findElement('Appointment.description');
@@ -307,7 +307,7 @@ describe('StructureDefinitionExporter', () => {
     vsRule.strength = 'extensible';
     profile.rules.push(vsRule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
     const baseElement = baseStructDef.findElement('Observation.category');
@@ -327,7 +327,7 @@ describe('StructureDefinitionExporter', () => {
     vsRule.strength = 'extensible';
     profile.rules.push(vsRule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
     const baseElement = baseStructDef.findElement('Observation.note');
@@ -345,7 +345,7 @@ describe('StructureDefinitionExporter', () => {
     vsRule.strength = 'example';
     profile.rules.push(vsRule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
     const baseElement = baseStructDef.findElement('Observation.category');
@@ -367,7 +367,7 @@ describe('StructureDefinitionExporter', () => {
     rule.types = [{ type: 'string' }];
     profile.rules.push(rule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
@@ -391,7 +391,7 @@ describe('StructureDefinitionExporter', () => {
     rule.types = [{ type: 'Device', isReference: true }];
     profile.rules.push(rule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
@@ -431,7 +431,7 @@ describe('StructureDefinitionExporter', () => {
     ];
     profile.rules.push(rule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
@@ -473,7 +473,7 @@ describe('StructureDefinitionExporter', () => {
     rule.types = [{ type: 'instant' }];
     profile.rules.push(rule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
@@ -494,7 +494,7 @@ describe('StructureDefinitionExporter', () => {
     rule.fixedValue = fixedFshCode;
     profile.rules.push(rule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
@@ -516,7 +516,7 @@ describe('StructureDefinitionExporter', () => {
     rule.fixedValue = true; // Incorrect boolean
     profile.rules.push(rule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
@@ -539,7 +539,7 @@ describe('StructureDefinitionExporter', () => {
     rule.max = '1';
     profile.rules.push(rule);
 
-    exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
     const json = sd.toJSON();
 

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -34,7 +34,8 @@ describe('StructureDefinitionExporter', () => {
     profile.title = 'Foo Profile';
     profile.description = 'foo bar foobar';
     doc.profiles.set(profile.name, profile);
-    const exported = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const exported = exporter.structDefs[0];
     expect(exported.name).toBe('Foo');
     expect(exported.id).toBe('foo');
     expect(exported.title).toBe('Foo Profile');
@@ -48,7 +49,8 @@ describe('StructureDefinitionExporter', () => {
   it('should not overwrite metadata that is not given for a profile', () => {
     const profile = new Profile('Foo');
     doc.profiles.set(profile.name, profile);
-    const exported = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const exported = exporter.structDefs[0];
     expect(exported.name).toBe('Foo');
     expect(exported.id).toBe('Foo');
     expect(exported.title).toBeUndefined();
@@ -75,7 +77,8 @@ describe('StructureDefinitionExporter', () => {
     extension.title = 'Foo Profile';
     extension.description = 'foo bar foobar';
     doc.extensions.set(extension.name, extension);
-    const exported = exporter.exportStructDef(extension, input);
+    exporter.exportStructDef(extension, input);
+    const exported = exporter.structDefs[0];
     expect(exported.name).toBe('Foo');
     expect(exported.id).toBe('foo');
     expect(exported.title).toBe('Foo Profile');
@@ -97,7 +100,8 @@ describe('StructureDefinitionExporter', () => {
   it('should not overwrite metadata that is not given for an extension', () => {
     const extension = new Extension('Foo');
     doc.extensions.set(extension.name, extension);
-    const exported = exporter.exportStructDef(extension, input);
+    exporter.exportStructDef(extension, input);
+    const exported = exporter.structDefs[0];
     expect(exported.name).toBe('Foo');
     expect(exported.id).toBe('Foo');
     expect(exported.title).toBeUndefined();
@@ -126,7 +130,8 @@ describe('StructureDefinitionExporter', () => {
     const extension = new Extension('Foo');
     extension.parent = 'http://hl7.org/fhir/StructureDefinition/patient-animal';
     doc.extensions.set(extension.name, extension);
-    const exported = exporter.exportStructDef(extension, input);
+    exporter.exportStructDef(extension, input);
+    const exported = exporter.structDefs[0];
     expect(exported.context).toEqual([
       {
         type: 'element',
@@ -152,7 +157,8 @@ describe('StructureDefinitionExporter', () => {
     rule.min = 0;
     rule.max = '1';
     profile.rules.push(rule);
-    const structDef = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const structDef = exporter.structDefs[0];
     expect(structDef).toBeDefined();
     expect(structDef.type).toBe('Resource');
   });
@@ -167,7 +173,8 @@ describe('StructureDefinitionExporter', () => {
     rule.max = '1';
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
     const baseCard = baseStructDef.findElement('Observation.subject');
@@ -189,7 +196,8 @@ describe('StructureDefinitionExporter', () => {
     rule.max = '1';
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
     const baseCard = baseStructDef.findElement('Observation.status');
@@ -211,7 +219,8 @@ describe('StructureDefinitionExporter', () => {
     rule.mustSupport = true;
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
     const baseElement = baseStructDef.findElement('DiagnosticReport.conclusion');
@@ -233,7 +242,8 @@ describe('StructureDefinitionExporter', () => {
     rule.mustSupport = true;
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
     const baseElement = baseStructDef.findElement('DiagnosticReport.status');
@@ -254,7 +264,8 @@ describe('StructureDefinitionExporter', () => {
     rule.mustSupport = false;
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
     const baseElement = baseStructDef.findElement('Observation.code');
@@ -277,7 +288,8 @@ describe('StructureDefinitionExporter', () => {
     vsRule.strength = 'extensible';
     profile.rules.push(vsRule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
     const baseElement = baseStructDef.findElement('Appointment.description');
     const changedElement = sd.findElement('Appointment.description');
@@ -295,7 +307,8 @@ describe('StructureDefinitionExporter', () => {
     vsRule.strength = 'extensible';
     profile.rules.push(vsRule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
     const baseElement = baseStructDef.findElement('Observation.category');
     const changedElement = sd.findElement('Observation.category');
@@ -314,7 +327,8 @@ describe('StructureDefinitionExporter', () => {
     vsRule.strength = 'extensible';
     profile.rules.push(vsRule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
     const baseElement = baseStructDef.findElement('Observation.note');
     const changedElement = sd.findElement('Observation.note');
@@ -331,7 +345,8 @@ describe('StructureDefinitionExporter', () => {
     vsRule.strength = 'example';
     profile.rules.push(vsRule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
     const baseElement = baseStructDef.findElement('Observation.category');
     const changedElement = sd.findElement('Observation.category');
@@ -352,7 +367,8 @@ describe('StructureDefinitionExporter', () => {
     rule.types = [{ type: 'string' }];
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
     const baseValue = baseStructDef.findElement('Observation.value[x]');
@@ -375,7 +391,8 @@ describe('StructureDefinitionExporter', () => {
     rule.types = [{ type: 'Device', isReference: true }];
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
     const baseSubject = baseStructDef.findElement('Observation.subject');
@@ -414,7 +431,8 @@ describe('StructureDefinitionExporter', () => {
     ];
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
     const baseHasMember = baseStructDef.findElement('Observation.hasMember');
@@ -455,7 +473,8 @@ describe('StructureDefinitionExporter', () => {
     rule.types = [{ type: 'instant' }];
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
     const baseValue = baseStructDef.findElement('Observation.value[x]');
@@ -475,7 +494,8 @@ describe('StructureDefinitionExporter', () => {
     rule.fixedValue = fixedFshCode;
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
     const baseCode = baseStructDef.findElement('Observation.code');
@@ -496,7 +516,8 @@ describe('StructureDefinitionExporter', () => {
     rule.fixedValue = true; // Incorrect boolean
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
     const baseCode = baseStructDef.findElement('Observation.code');
@@ -518,7 +539,8 @@ describe('StructureDefinitionExporter', () => {
     rule.max = '1';
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile, input);
+    const sd = exporter.structDefs[0];
     const json = sd.toJSON();
 
     expect(json.differential.element).toHaveLength(1);


### PR DESCRIPTION
This PR adds support for FSHy Parents. This means that if the Parent of a Profile or Extension is another Profile or Extension, respectively, then the exporter process will export in the correct order so that Profiles and Extensions can be based on one another.

In order to test this, just run `npm run check` on this branch. I added what I believe to be comprehensive tests to cover various cases. If you think I'm missing any, let me know!