### PR TITLE
Include FSH source information in log statements

### DIFF
--- a/src/errors/ParentNotDefinedError.ts
+++ b/src/errors/ParentNotDefinedError.ts
@@ -1,8 +1,10 @@
 import { Annotated } from './Annotated';
+import { WithSource } from './WithSource';
+import { SourceInfo } from '../fshtypes';
 
-export class ParentNotDefinedError extends Error implements Annotated {
+export class ParentNotDefinedError extends Error implements Annotated, WithSource {
   specReferences = ['https://www.hl7.org/fhir/R4/profiling.html#resources'];
-  constructor(public childName: string, public parentName: string) {
+  constructor(public childName: string, public parentName: string, public sourceInfo: SourceInfo) {
     super(`Parent ${parentName} not found for ${childName}`);
   }
 }

--- a/src/errors/WithSource.ts
+++ b/src/errors/WithSource.ts
@@ -1,0 +1,5 @@
+import { SourceInfo } from '../fshtypes';
+
+export interface WithSource {
+  sourceInfo: SourceInfo;
+}

--- a/src/export/ExtensionExporter.ts
+++ b/src/export/ExtensionExporter.ts
@@ -18,7 +18,7 @@ export class ExtensionExporter extends StructureDefinitionExporter {
       try {
         this.exportStructDef(extension);
       } catch (e) {
-        logger.error(e.message);
+        logger.error(e.message, e.sourceInfo);
       }
     }
     return this.structDefs;

--- a/src/export/ProfileExporter.ts
+++ b/src/export/ProfileExporter.ts
@@ -22,7 +22,7 @@ export class ProfileExporter extends StructureDefinitionExporter {
           const structDef = this.exportStructDef(profile, tank);
           structDefs.push(structDef);
         } catch (e) {
-          logger.error(e.message);
+          logger.error(e.message, e.sourceInfo);
         }
       }
     }

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -75,7 +75,7 @@ export class StructureDefinitionExporter {
             element.bindToVS(rule.valueSet, rule.strength as ElementDefinitionBindingStrength);
           }
         } catch (e) {
-          logger.error(e.message);
+          logger.error(e.message, rule.sourceInfo);
         }
       } else {
         logger.error(
@@ -110,7 +110,7 @@ export class StructureDefinitionExporter {
     if (jsonParent) {
       structDef = StructureDefinition.fromJSON(jsonParent);
     } else {
-      throw new ParentNotDefinedError(fshDefinition.name, parentName);
+      throw new ParentNotDefinedError(fshDefinition.name, parentName, fshDefinition.sourceInfo);
     }
     // Capture the orginal elements so that any further changes are reflected in the differential
     structDef.captureOriginalElements();

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -79,7 +79,8 @@ export class StructureDefinitionExporter {
         }
       } else {
         logger.error(
-          `No element found at path ${rule.path} for ${fshDefinition.name}, skipping rule`
+          `No element found at path ${rule.path} for ${fshDefinition.name}, skipping rule`,
+          rule.sourceInfo
         );
       }
     }
@@ -102,6 +103,7 @@ export class StructureDefinitionExporter {
    * @param {Profile | Extension} fshDefinition - The Profile or Extension we are exporting
    * @param {FSHTank} tank - The FSH tank we are exporting
    * @returns {StructureDefinition}
+   * @throws {ParentNotDefinedError} when the Profile or Extension's parent is not found
    */
   exportStructDef(fshDefinition: Profile | Extension, tank: FSHTank): StructureDefinition {
     const parentName = fshDefinition.parent || 'Resource';

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -174,7 +174,10 @@ export class FSHImporter extends FSHVisitor {
     } else if (ctx.containsRule()) {
       return this.visitContainsRule(ctx.containsRule());
     }
-    logger.warn(`Unsupported rule: ${ctx.getText()}`);
+    logger.warn(`Unsupported rule: ${ctx.getText()}`, {
+      file: this.file,
+      location: this.extractStartStop(ctx)
+    });
     return [];
   }
 

--- a/src/utils/FSHLogger.ts
+++ b/src/utils/FSHLogger.ts
@@ -2,7 +2,7 @@ import { createLogger, format, transports } from 'winston';
 
 const { combine, colorize, simple } = format;
 
-const withLocation = format((info, opts) => {
+const withLocation = format(info => {
   if (info.file) {
     info.message += `\nFile: ${info.file}`;
     delete info.file;

--- a/src/utils/FSHLogger.ts
+++ b/src/utils/FSHLogger.ts
@@ -2,7 +2,20 @@ import { createLogger, format, transports } from 'winston';
 
 const { combine, colorize, simple } = format;
 
+const withLocation = format((info, opts) => {
+  if (info.file) {
+    info.message += `\nFile: ${info.file}`;
+    delete info.file;
+  }
+  if (info.location) {
+    info.message += `\nFrom: (Line ${info.location.startLine}, Column ${info.location.startColumn})`;
+    info.message += `\nTo: (Line ${info.location.endLine}, Column ${info.location.endColumn})`;
+    delete info.location;
+  }
+  return info;
+});
+
 export const logger = createLogger({
-  format: combine(colorize({ all: true }), simple()),
+  format: combine(withLocation(), colorize({ all: true }), simple()),
   transports: [new transports.Console()]
 });

--- a/test/export/ProfileExporter.test.ts
+++ b/test/export/ProfileExporter.test.ts
@@ -2,6 +2,7 @@ import { ProfileExporter } from '../../src/export';
 import { FSHTank, FSHDocument } from '../../src/import';
 import { FHIRDefinitions, load } from '../../src/fhirdefs';
 import { Profile } from '../../src/fshtypes';
+import { logger } from '../../src/utils/FSHLogger';
 
 describe('ProfileExporter', () => {
   let defs: FHIRDefinitions;
@@ -49,5 +50,17 @@ describe('ProfileExporter', () => {
     const exported = exporter.export(input);
     expect(exported.length).toBe(1);
     expect(exported[0].name).toBe('Bar');
+  });
+
+  it('should log a message with source information when the parent is not found', () => {
+    const profile = new Profile('Bogus').withFile('Bogus.fsh').withLocation([2, 9, 4, 23]);
+    profile.parent = 'BogusParent';
+    doc.profiles.set(profile.name, profile);
+
+    const mockWriter = jest.spyOn(logger.transports[0], 'write');
+    exporter.export(input);
+    expect(mockWriter.mock.calls[0][0].message).toMatch(
+      /Parent BogusParent not found for Bogus.*File: Bogus\.fsh.*Line 2\D.*Column 9\D.*Line 4\D.*Column 23\D/s
+    );
   });
 });

--- a/test/export/ProfileExporter.test.ts
+++ b/test/export/ProfileExporter.test.ts
@@ -9,9 +9,11 @@ describe('ProfileExporter', () => {
   let doc: FSHDocument;
   let input: FSHTank;
   let exporter: ProfileExporter;
+  let mockWriter: jest.SpyInstance<boolean, [any, string, ((error: Error) => void)?]>;
 
   beforeAll(() => {
     defs = load('4.0.1');
+    mockWriter = jest.spyOn(logger.transports[0], 'write');
   });
 
   beforeEach(() => {
@@ -56,10 +58,8 @@ describe('ProfileExporter', () => {
     const profile = new Profile('Bogus').withFile('Bogus.fsh').withLocation([2, 9, 4, 23]);
     profile.parent = 'BogusParent';
     doc.profiles.set(profile.name, profile);
-
-    const mockWriter = jest.spyOn(logger.transports[0], 'write');
     exporter.export();
-    expect(mockWriter.mock.calls[0][0].message).toMatch(
+    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
       /File: Bogus\.fsh.*Line 2\D.*Column 9\D.*Line 4\D.*Column 23\D/s
     );
   });

--- a/test/export/ProfileExporter.test.ts
+++ b/test/export/ProfileExporter.test.ts
@@ -60,7 +60,7 @@ describe('ProfileExporter', () => {
     const mockWriter = jest.spyOn(logger.transports[0], 'write');
     exporter.export(input);
     expect(mockWriter.mock.calls[0][0].message).toMatch(
-      /Parent BogusParent not found for Bogus.*File: Bogus\.fsh.*Line 2\D.*Column 9\D.*Line 4\D.*Column 23\D/s
+      /File: Bogus\.fsh.*Line 2\D.*Column 9\D.*Line 4\D.*Column 23\D/s
     );
   });
 });

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -9,15 +9,18 @@ import {
   ValueSetRule,
   FixedValueRule
 } from '../../src/fshtypes/rules';
+import { logger } from '../../src/utils/FSHLogger';
 
 describe('StructureDefinitionExporter', () => {
   let defs: FHIRDefinitions;
   let doc: FSHDocument;
   let input: FSHTank;
   let exporter: StructureDefinitionExporter;
+  let mockWriter: jest.SpyInstance<boolean, [any, string, ((error: Error) => void)?]>;
 
   beforeAll(() => {
     defs = load('4.0.1');
+    mockWriter = jest.spyOn(logger.transports[0], 'write');
   });
 
   beforeEach(() => {
@@ -146,15 +149,17 @@ describe('StructureDefinitionExporter', () => {
 
   // Rules
   it('should emit an error and continue when the path is not found', () => {
-    // TODO: This should check for emitting an error once we have logging
     const profile = new Profile('Foo');
-    const rule = new CardRule('fakePath');
+    const rule = new CardRule('fakePath').withFile('Foo.fsh').withLocation([3, 8, 4, 22]);
     rule.min = 0;
     rule.max = '1';
     profile.rules.push(rule);
     const structDef = exporter.exportStructDef(profile, input);
     expect(structDef).toBeDefined();
     expect(structDef.type).toBe('Resource');
+    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
+      /File: Foo\.fsh.*Line 3\D.*Column 8\D.*Line 4\D.*Column 22\D/s
+    );
   });
 
   // Card Rule
@@ -180,11 +185,10 @@ describe('StructureDefinitionExporter', () => {
   });
 
   it('should not apply an incorrect card rule', () => {
-    // TODO: this should check for emitting an error once logging is setup
     const profile = new Profile('Foo');
     profile.parent = 'Observation';
 
-    const rule = new CardRule('status');
+    const rule = new CardRule('status').withFile('Wrong.fsh').withLocation([5, 4, 5, 11]);
     rule.min = 0;
     rule.max = '1';
     profile.rules.push(rule);
@@ -199,6 +203,9 @@ describe('StructureDefinitionExporter', () => {
     expect(baseCard.max).toBe('1');
     expect(changedCard.min).toBe(1);
     expect(changedCard.max).toBe('1');
+    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
+      /File: Wrong\.fsh.*Line 5\D.*Column 4\D.*Line 5\D.*Column 11\D/s
+    );
   });
 
   // Flag Rule
@@ -228,7 +235,7 @@ describe('StructureDefinitionExporter', () => {
     const profile = new Profile('Foo');
     profile.parent = 'DiagnosticReport';
 
-    const rule = new FlagRule('status');
+    const rule = new FlagRule('status').withFile('Nope.fsh').withLocation([8, 7, 8, 15]);
     rule.modifier = false;
     rule.mustSupport = true;
     profile.rules.push(rule);
@@ -242,13 +249,16 @@ describe('StructureDefinitionExporter', () => {
     expect(baseElement.mustSupport).toBeFalsy();
     expect(changedElement.isModifier).toBe(true);
     expect(changedElement.mustSupport).toBeFalsy();
+    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
+      /File: Nope\.fsh.*Line 8\D.*Column 7\D.*Line 8\D.*Column 15\D/s
+    );
   });
 
   it('should not apply a flag rule that disables mustSupport', () => {
     const profile = new Profile('Foo');
     profile.parent = 'http://hl7.org/fhir/StructureDefinition/vitalsigns';
 
-    const rule = new FlagRule('code');
+    const rule = new FlagRule('code').withFile('Nope.fsh').withLocation([8, 7, 8, 15]);
     rule.modifier = true;
     rule.summary = false;
     rule.mustSupport = false;
@@ -265,6 +275,9 @@ describe('StructureDefinitionExporter', () => {
     expect(changedElement.isModifier).toBeFalsy();
     expect(changedElement.isSummary).toBe(true);
     expect(changedElement.mustSupport).toBe(true);
+    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
+      /File: Nope\.fsh.*Line 8\D.*Column 7\D.*Line 8\D.*Column 15\D/s
+    );
   });
 
   // Value Set Rule
@@ -309,7 +322,7 @@ describe('StructureDefinitionExporter', () => {
     const profile = new Profile('Foo');
     profile.parent = 'Observation';
 
-    const vsRule = new ValueSetRule('note');
+    const vsRule = new ValueSetRule('note').withFile('Codeless.fsh').withLocation([6, 9, 6, 25]);
     vsRule.valueSet = 'http://example.org/fhir/ValueSet/some-valueset';
     vsRule.strength = 'extensible';
     profile.rules.push(vsRule);
@@ -320,13 +333,16 @@ describe('StructureDefinitionExporter', () => {
     const changedElement = sd.findElement('Observation.note');
     expect(baseElement.binding).toBeUndefined();
     expect(changedElement.binding).toBeUndefined();
+    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
+      /File: Codeless\.fsh.*Line 6\D.*Column 9\D.*Line 6\D.*Column 25\D/s
+    );
   });
 
   it('should not override a binding with a less strict binding', () => {
     const profile = new Profile('Foo');
     profile.parent = 'Observation';
 
-    const vsRule = new ValueSetRule('category');
+    const vsRule = new ValueSetRule('category').withFile('Strict.fsh').withLocation([9, 10, 9, 35]);
     vsRule.valueSet = 'http://example.org/fhir/ValueSet/some-valueset';
     vsRule.strength = 'example';
     profile.rules.push(vsRule);
@@ -341,6 +357,9 @@ describe('StructureDefinitionExporter', () => {
       'http://hl7.org/fhir/ValueSet/observation-category'
     );
     expect(changedElement.binding.strength).toBe('preferred');
+    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
+      /File: Strict\.fsh.*Line 9\D.*Column 10\D.*Line 9\D.*Column 35\D/s
+    );
   });
 
   // Only Rule
@@ -447,11 +466,10 @@ describe('StructureDefinitionExporter', () => {
   });
 
   it('should not apply an incorrect OnlyRule', () => {
-    // TODO: this should check for emitting an error once logging is set up
     const profile = new Profile('Foo');
     profile.parent = 'Observation';
 
-    const rule = new OnlyRule('value[x]');
+    const rule = new OnlyRule('value[x]').withFile('Only.fsh').withLocation([10, 12, 10, 22]);
     rule.types = [{ type: 'instant' }];
     profile.rules.push(rule);
 
@@ -463,6 +481,9 @@ describe('StructureDefinitionExporter', () => {
 
     expect(baseValue.type).toHaveLength(11);
     expect(constrainedValue.type).toHaveLength(11);
+    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
+      /File: Only\.fsh.*Line 10\D.*Column 12\D.*Line 10\D.*Column 22\D/s
+    );
   });
 
   // Fixed Value Rule
@@ -488,11 +509,10 @@ describe('StructureDefinitionExporter', () => {
   });
 
   it('should not apply an incorrect FixedValueRule', () => {
-    // TODO: this should check for emitting an error once logging is set up
     const profile = new Profile('Foo');
     profile.parent = 'Observation';
 
-    const rule = new FixedValueRule('code');
+    const rule = new FixedValueRule('code').withFile('Fixed.fsh').withLocation([4, 18, 4, 28]);
     rule.fixedValue = true; // Incorrect boolean
     profile.rules.push(rule);
 
@@ -504,6 +524,9 @@ describe('StructureDefinitionExporter', () => {
 
     expect(baseCode.patternCodeableConcept).toBeUndefined();
     expect(fixedCode.patternCodeableConcept).toBeUndefined(); // Code remains unset
+    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
+      /File: Fixed\.fsh.*Line 4\D.*Column 18\D.*Line 4\D.*Column 28\D/s
+    );
   });
 
   // toJSON

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -8,8 +8,15 @@ import {
 } from '../utils/asserts';
 import { importText } from '../../src/import';
 import { FshCode, FshQuantity, FshRatio } from '../../src/fshtypes';
+import { logger } from '../../src/utils/FSHLogger';
 
 describe('FSHImporter', () => {
+  let mockWriter: jest.SpyInstance<boolean, [any, string, ((error: Error) => void)?]>;
+
+  beforeAll(() => {
+    mockWriter = jest.spyOn(logger.transports[0], 'write');
+  });
+
   describe('Profile', () => {
     describe('#sdMetadata', () => {
       it('should parse the simplest possible profile', () => {
@@ -761,6 +768,24 @@ describe('FSHImporter', () => {
       assertFlagRule(profile.rules[2], 'component[SystolicBP]', true, undefined, undefined);
       assertCardRule(profile.rules[3], 'component[DiastolicBP]', 2, '*');
       assertFlagRule(profile.rules[4], 'component[DiastolicBP]', true, true, undefined);
+    });
+  });
+
+  describe('#obeysRule', () => {
+    // the current importer does not support obeys rule.
+    // this test should be removed once obeys rules are supported.
+    it('should issue a message when parsing an obeys rule', () => {
+      const input = `
+      Profile: ObservationProfile
+      Parent: Observation
+      * category obeys SomeInvariant
+      `;
+      const result = importText(input, 'Obeys.fsh');
+      const profile = result.profiles.get('ObservationProfile');
+      expect(profile.rules).toHaveLength(0);
+      expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
+        /File: Obeys\.fsh.*Line 4\D.*Column 7\D.*Line 4\D.*Column 36\D/s
+      );
     });
   });
 });


### PR DESCRIPTION
This comes with several test cases that check the source information, but not the specific text associated with the error being thrown.

I ended up only using the `WithSource` interface on `ParentNotDefinedError`, since that's the only error that gets caught and logged in a location where the source information would not normally be accessible.

Also, as it turns out, jest's `SpyInstance` can do some pretty handy stuff.

This pull request addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-141.