### PR TITLE
Choice slice renaming in differential

### DIFF
--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -225,6 +225,16 @@ export class ElementDefinition {
         diff[prop] = cloneDeep(this[prop]);
       }
     }
+    // If the id is a choice slice, we change the id/path in the differential to use a shortcut syntax
+    // described here https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/.
+    // Path gets set automatically when setting id
+    diff.id = diff.id
+      .split('.')
+      .map(p => {
+        const i = p.indexOf('[x]:');
+        return i > -1 ? p.slice(i + 4) : p;
+      })
+      .join('.');
     return diff;
   }
 

--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -176,6 +176,17 @@ describe('ElementDefinition', () => {
       expect(diff.fixedInteger).toBe(2);
       expect(Object.keys(diff.toJSON())).toHaveLength(3);
     });
+
+    it('should calculate diff id using shortcut syntax for a choice slice', () => {
+      valueX.sliceIt('type', '$this', false, 'open');
+      const valueString = valueX.addSlice('valueString', { code: 'string' });
+      const diff = valueString.calculateDiff();
+      expect(valueString.id).toBe('Observation.value[x]:valueString');
+      expect(valueString.path).toBe('Observation.value[x]');
+      expect(diff.id).toBe('Observation.valueString');
+      expect(diff.path).toBe('Observation.valueString');
+      expect(Object.keys(diff.toJSON()).length).toBe(Object.keys(valueString.toJSON()).length);
+    });
   });
 
   describe('#parent', () => {


### PR DESCRIPTION
This adds renaming of a choice slice in the differential element. When a choice element is sliced, it has an `id` like `Observation.value[x]:valueString`, and a `path` like `Observation.value[x]` in the snapshot. According to this blog post https://blog.fire.ly/2019/09/13/type-slicing-in-fhir-r4/, the best practice is to rename the `id` and `path` in the differential so that they are both of the form `Observation.valueString`. Note that this assumes the `id` is of the form described here https://www.hl7.org/fhir/elementdefinition.html#id.