### PR TITLE
Export contains rule

### DIFF
--- a/src/errors/InvalidMaxOfSliceError.ts
+++ b/src/errors/InvalidMaxOfSliceError.ts
@@ -1,0 +1,10 @@
+import { Annotated } from './Annotated';
+
+export class InvalidMaxOfSliceError extends Error implements Annotated {
+  specReferences = ['http://www.hl7.org/fhiR/profiling.html#slice-cardinality'];
+  constructor(public sliceMax: string, public slicedElementMax: string) {
+    super(
+      `No individual slice may have max >= max of sliced element, but max of slice ${sliceMax} is > max of sliced element ${slicedElementMax}.`
+    );
+  }
+}

--- a/src/errors/InvalidMaxOfSliceError.ts
+++ b/src/errors/InvalidMaxOfSliceError.ts
@@ -2,9 +2,9 @@ import { Annotated } from './Annotated';
 
 export class InvalidMaxOfSliceError extends Error implements Annotated {
   specReferences = ['http://www.hl7.org/fhiR/profiling.html#slice-cardinality'];
-  constructor(public sliceMax: string, public slicedElementMax: string) {
+  constructor(public sliceMax: string, public sliceName: string, public slicedElementMax: string) {
     super(
-      `No individual slice may have max >= max of sliced element, but max of slice ${sliceMax} is > max of sliced element ${slicedElementMax}.`
+      `No individual slice may have max >= max of sliced element, but max ${sliceMax} of slice ${sliceName} > max of sliced element ${slicedElementMax}.`
     );
   }
 }

--- a/src/errors/InvalidMaxOfSliceError.ts
+++ b/src/errors/InvalidMaxOfSliceError.ts
@@ -1,10 +1,10 @@
 import { Annotated } from './Annotated';
 
 export class InvalidMaxOfSliceError extends Error implements Annotated {
-  specReferences = ['http://www.hl7.org/fhiR/profiling.html#slice-cardinality'];
+  specReferences = ['http://www.hl7.org/fhir/profiling.html#slice-cardinality'];
   constructor(public sliceMax: string, public sliceName: string, public slicedElementMax: string) {
     super(
-      `No individual slice may have max >= max of sliced element, but max ${sliceMax} of slice ${sliceName} > max of sliced element ${slicedElementMax}.`
+      `No individual slice may have max > max of sliced element, but max of slice ${sliceName} (${sliceMax}) > max of sliced element (${slicedElementMax}).`
     );
   }
 }

--- a/src/errors/InvalidSumOfSliceMinsError.ts
+++ b/src/errors/InvalidSumOfSliceMinsError.ts
@@ -1,0 +1,10 @@
+import { Annotated } from './Annotated';
+
+export class InvalidSumOfSliceMinsError extends Error implements Annotated {
+  specReferences = ['http://www.hl7.org/fhiR/profiling.html#slice-cardinality'];
+  constructor(public sumMins: number, public max: string) {
+    super(
+      `The sum of mins of slices must be <= max of sliced element, but sum of mins ${sumMins} is > max ${max}.`
+    );
+  }
+}

--- a/src/errors/InvalidSumOfSliceMinsError.ts
+++ b/src/errors/InvalidSumOfSliceMinsError.ts
@@ -1,10 +1,10 @@
 import { Annotated } from './Annotated';
 
 export class InvalidSumOfSliceMinsError extends Error implements Annotated {
-  specReferences = ['http://www.hl7.org/fhiR/profiling.html#slice-cardinality'];
+  specReferences = ['http://www.hl7.org/fhir/profiling.html#slice-cardinality'];
   constructor(public sumMins: number, public max: string, public slicedElementId: string) {
     super(
-      `The sum of mins of slices must be <= max of sliced element, but sum of mins ${sumMins} > max ${max} of ${slicedElementId}.`
+      `The sum of mins of slices must be <= max of sliced element, but sum of mins (${sumMins}) > max (${max}) of ${slicedElementId}.`
     );
   }
 }

--- a/src/errors/InvalidSumOfSliceMinsError.ts
+++ b/src/errors/InvalidSumOfSliceMinsError.ts
@@ -2,9 +2,9 @@ import { Annotated } from './Annotated';
 
 export class InvalidSumOfSliceMinsError extends Error implements Annotated {
   specReferences = ['http://www.hl7.org/fhiR/profiling.html#slice-cardinality'];
-  constructor(public sumMins: number, public max: string) {
+  constructor(public sumMins: number, public max: string, public slicedElementId: string) {
     super(
-      `The sum of mins of slices must be <= max of sliced element, but sum of mins ${sumMins} is > max ${max}.`
+      `The sum of mins of slices must be <= max of sliced element, but sum of mins ${sumMins} > max ${max} of ${slicedElementId}.`
     );
   }
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -19,3 +19,5 @@ export * from './UnitMismatchError';
 export * from './WideningCardinalityError';
 export * from './CannotResolvePathError';
 export * from './InvalidElementAccessError';
+export * from './InvalidSumOfSliceMinsError';
+export * from './InvalidMaxOfSliceError';

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -3,7 +3,14 @@ import { StructureDefinition, ElementDefinitionBindingStrength } from '../fhirty
 import { Profile, Extension } from '../fshtypes';
 import { FSHTank } from '../import';
 import { ParentNotDefinedError } from '../errors/ParentNotDefinedError';
-import { CardRule, FixedValueRule, FlagRule, OnlyRule, ValueSetRule } from '../fshtypes/rules';
+import {
+  CardRule,
+  FixedValueRule,
+  FlagRule,
+  OnlyRule,
+  ValueSetRule,
+  ContainsRule
+} from '../fshtypes/rules';
 import { logger } from '../utils/FSHLogger';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -71,6 +78,8 @@ export class StructureDefinitionExporter {
             element.constrainType(rule.types, this.resolve.bind(this), target);
           } else if (rule instanceof ValueSetRule) {
             element.bindToVS(rule.valueSet, rule.strength as ElementDefinitionBindingStrength);
+          } else if (rule instanceof ContainsRule) {
+            rule.items.forEach(item => element.addSlice(item));
           }
         } catch (e) {
           logger.error(e.message, rule.sourceInfo);

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -279,12 +279,12 @@ export class ElementDefinition {
       const sumOfMins = slices.reduce((prev, curr) => (prev += curr.min), 0);
       // Check that new max >= sum of mins of children
       if (!isUnbounded && sumOfMins > maxInt) {
-        throw new InvalidSumOfSliceMinsError(sumOfMins, max);
+        throw new InvalidSumOfSliceMinsError(sumOfMins, max, this.id);
       }
       // Check that new max >= every individual child max
       const overMaxChild = slices.find(child => child.max === '*' || parseInt(child.max) > maxInt);
       if (!isUnbounded && overMaxChild) {
-        throw new InvalidMaxOfSliceError(overMaxChild.max, max);
+        throw new InvalidMaxOfSliceError(overMaxChild.max, overMaxChild.sliceName, max);
       }
     }
 
@@ -297,7 +297,7 @@ export class ElementDefinition {
       const sumOfMins = min + slices.reduce((prev, curr) => (prev += curr.min), 0);
       // Check that slicedElement max >= new sum of mins
       if (slicedElement.max !== '*' && sumOfMins > parseInt(slicedElement.max)) {
-        throw new InvalidSumOfSliceMinsError(sumOfMins, slicedElement.max);
+        throw new InvalidSumOfSliceMinsError(sumOfMins, slicedElement.max, slicedElement.id);
       }
       // If new sum of mins > slicedElement min, increase slicedElement min
       if (sumOfMins > slicedElement.min) {

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -251,6 +251,8 @@ export class ElementDefinition {
    * @param {number|string} max - the maximum cardinality
    * @throws {InvalidCardinalityError} when min > max
    * @throws {WideningCardinalityError} when new cardinality is wider than existing cardinality
+   * @throws {InvalidSumOfSliceMinsError} when the mins of slice elements > max of sliced element
+   * @throws {InvalidMaxOfSliceError} when a sliced element's max is < an individual slice's max
    */
   constrainCardinality(min: number, max: string): void {
     const isUnbounded = max === '*';
@@ -275,13 +277,10 @@ export class ElementDefinition {
     // http://www.hl7.org/fhiR/profiling.html#slice-cardinality
     // If element is slice definition
     if (this.slicing) {
-      const slices = this.structDef.elements.filter(e => e.id !== this.id && e.path === this.path);
-      const sumOfMins = slices.reduce((prev, curr) => (prev += curr.min), 0);
       // Check that new max >= sum of mins of children
-      if (!isUnbounded && sumOfMins > maxInt) {
-        throw new InvalidSumOfSliceMinsError(sumOfMins, max, this.id);
-      }
+      this.checkSumOfSliceMins(max);
       // Check that new max >= every individual child max
+      const slices = this.structDef.elements.filter(e => e.id !== this.id && e.path === this.path);
       const overMaxChild = slices.find(child => child.max === '*' || parseInt(child.max) > maxInt);
       if (!isUnbounded && overMaxChild) {
         throw new InvalidMaxOfSliceError(overMaxChild.max, overMaxChild.sliceName, max);
@@ -289,23 +288,39 @@ export class ElementDefinition {
     }
 
     // If element is a slice
-    const slicedElement = this.structDef.elements.find(e => e.path === this.path && e.slicing);
-    if (slicedElement) {
-      const slices = this.structDef.elements.filter(
-        e => e.id !== this.id && e.path === this.path && !e.slicing
-      );
-      const sumOfMins = min + slices.reduce((prev, curr) => (prev += curr.min), 0);
-      // Check that slicedElement max >= new sum of mins
-      if (slicedElement.max !== '*' && sumOfMins > parseInt(slicedElement.max)) {
-        throw new InvalidSumOfSliceMinsError(sumOfMins, slicedElement.max, slicedElement.id);
-      }
-      // If new sum of mins > slicedElement min, increase slicedElement min
-      if (sumOfMins > slicedElement.min) {
-        slicedElement.min = sumOfMins;
+    if (this.sliceName) {
+      const slicedElement = this.structDef.elements.find(e => e.path === this.path && e.slicing);
+      if (slicedElement) {
+        // Check that slicedElement max >= new sum of mins
+        const sumOfMins = slicedElement.checkSumOfSliceMins(slicedElement.max, min - this.min);
+        // If new sum of mins > slicedElement min, increase slicedElement min
+        if (sumOfMins > slicedElement.min) {
+          slicedElement.min = sumOfMins;
+        }
       }
     }
 
     [this.min, this.max] = [min, max];
+  }
+
+  /**
+   * Checks if the sum of slice mins exceeds the max of sliced element, and returns
+   * the sum if so.
+   * @param {string} slicedElementMax - The max of the sliced element
+   * @param {number} newSliceMin - An optional new minimum if the minimum of this is being constrained
+   * @returns {number} the sum of the mins of the slices, or 0 if the sum is less than the sliced max
+   * @throws {InvalidSumOfSliceMinsError} when the sum of mins of the slices exceeds max of sliced element
+   */
+  private checkSumOfSliceMins(newSlicedElementMax: string, sliceMinIncrease = 0) {
+    const slices = this.structDef.elements.filter(
+      e => e.id !== this.id && e.path === this.path && !e.slicing
+    );
+    const sumOfMins = sliceMinIncrease + slices.reduce((prev, curr) => (prev += curr.min), 0);
+    if (newSlicedElementMax !== '*' && sumOfMins > parseInt(newSlicedElementMax)) {
+      throw new InvalidSumOfSliceMinsError(sumOfMins, newSlicedElementMax, this.id);
+    } else {
+      return sumOfMins;
+    }
   }
 
   /**
@@ -1302,7 +1317,9 @@ export class ElementDefinition {
     delete slice.slicing;
     slice.id = `${this.id}:${name}`;
     slice.sliceName = name;
-    // When a we slice, we do not inherit min cardinality, but rather make it 0
+    // When we slice, we do not inherit min cardinality, but rather make it 0
+    // Allows multiple slices to be defined without violating cardinality of sliced element
+    // Cardinality can be later narrowed by card constraints, which check validity of narrowing
     // According to https://chat.fhir.org/#narrow/stream/179239-tooling/topic/Slicing.201.2E.2E.3F.20element
     slice.min = 0;
     if (type) {

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -570,6 +570,29 @@ describe('StructureDefinitionExporter', () => {
     expect(barSlice).toBeDefined();
   });
 
+  it('should apply multiple ContainsRule on an element with defined slicing', () => {
+    const profile = new Profile('Foo');
+    profile.parent = 'resprate';
+
+    const rule1 = new ContainsRule('code.coding');
+    const rule2 = new ContainsRule('code.coding');
+    rule1.items = ['barSlice'];
+    rule2.items = ['fooSlice'];
+    profile.rules.push(rule1);
+    profile.rules.push(rule2);
+
+    exporter.exportStructDef(profile);
+    const sd = exporter.structDefs[0];
+    const baseStructDef = sd.getBaseStructureDefinition();
+
+    const barSlice = sd.elements.find(e => e.id === 'Observation.code.coding:barSlice');
+    const fooSlice = sd.elements.find(e => e.id === 'Observation.code.coding:fooSlice');
+
+    expect(sd.elements.length).toBe(baseStructDef.elements.length + 2);
+    expect(barSlice).toBeDefined();
+    expect(fooSlice).toBeDefined();
+  });
+
   it('should not apply a ContainsRule on an element without defined slicing', () => {
     const profile = new Profile('Foo');
     profile.parent = 'resprate';

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -560,7 +560,8 @@ describe('StructureDefinitionExporter', () => {
     rule.items = ['barSlice'];
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
     const barSlice = sd.elements.find(e => e.id === 'Observation.code.coding:barSlice');
@@ -570,21 +571,24 @@ describe('StructureDefinitionExporter', () => {
   });
 
   it('should not apply a ContainsRule on an element without defined slicing', () => {
-    // TODO: Should check for emitting an error
     const profile = new Profile('Foo');
     profile.parent = 'resprate';
 
-    const rule = new ContainsRule('identifier');
+    const rule = new ContainsRule('identifier').withFile('NoSlice.fsh').withLocation([6, 3, 6, 12]);
     rule.items = ['barSlice'];
     profile.rules.push(rule);
 
-    const sd = exporter.exportStructDef(profile, input);
+    exporter.exportStructDef(profile);
+    const sd = exporter.structDefs[0];
     const baseStructDef = sd.getBaseStructureDefinition();
 
     const barSlice = sd.elements.find(e => e.id === 'Observation.identifier:barSlice');
 
     expect(sd.elements.length).toBe(baseStructDef.elements.length);
     expect(barSlice).toBeUndefined();
+    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
+      /File: NoSlice\.fsh.*Line 6\D.*Column 3\D.*Line 6\D.*Column 12\D/s
+    );
   });
 
   // toJSON

--- a/test/fhirtypes/ElementDefinition.constrainCardinality.test.ts
+++ b/test/fhirtypes/ElementDefinition.constrainCardinality.test.ts
@@ -121,7 +121,7 @@ describe('ElementDefinition', () => {
       const clone = cloneDeep(category);
       expect(() => {
         category.constrainCardinality(1, '1');
-      }).toThrow(/2 > max 1 of Observation.category\./);
+      }).toThrow(/\(2\) > max \(1\) of Observation.category\./);
       expect(clone).toEqual(category);
     });
 
@@ -132,7 +132,7 @@ describe('ElementDefinition', () => {
       const clone = cloneDeep(category);
       expect(() => {
         category.constrainCardinality(1, '1');
-      }).toThrow(/max 2 of slice FooSlice > max of sliced element 1\./);
+      }).toThrow(/max of slice FooSlice \(2\) > max of sliced element \(1\)\./);
       expect(clone).toEqual(category);
     });
 
@@ -143,7 +143,7 @@ describe('ElementDefinition', () => {
       const clone = cloneDeep(fooSlice);
       expect(() => {
         fooSlice.constrainCardinality(2, '2');
-      }).toThrow(/3 > max 2 of Observation.category\./);
+      }).toThrow(/\(3\) > max \(2\) of Observation.category\./);
       expect(clone).toEqual(fooSlice);
     });
   });

--- a/test/fhirtypes/ElementDefinition.constrainCardinality.test.ts
+++ b/test/fhirtypes/ElementDefinition.constrainCardinality.test.ts
@@ -121,7 +121,7 @@ describe('ElementDefinition', () => {
       const clone = cloneDeep(category);
       expect(() => {
         category.constrainCardinality(1, '1');
-      }).toThrow(/2 is > max 1\./);
+      }).toThrow(/2 > max 1 of Observation.category\./);
       expect(clone).toEqual(category);
     });
 
@@ -132,7 +132,7 @@ describe('ElementDefinition', () => {
       const clone = cloneDeep(category);
       expect(() => {
         category.constrainCardinality(1, '1');
-      }).toThrow(/2 is > max of sliced element 1\./);
+      }).toThrow(/max 2 of slice FooSlice > max of sliced element 1\./);
       expect(clone).toEqual(category);
     });
 
@@ -143,7 +143,7 @@ describe('ElementDefinition', () => {
       const clone = cloneDeep(fooSlice);
       expect(() => {
         fooSlice.constrainCardinality(2, '2');
-      }).toThrow(/3 is > max 2\./);
+      }).toThrow(/3 > max 2 of Observation.category\./);
       expect(clone).toEqual(fooSlice);
     });
   });


### PR DESCRIPTION
This adds exporting of a `ContainsRule` constraint when there already existing a `slicing` on the `ElementDefinition`. To do this, we just need to call the `addSlice` function. This addresses CIMPL-139: https://standardhealthrecord.atlassian.net/browse/CIMPL-139.