### PR TITLE
Import CaretValueRule

### DIFF
--- a/src/fshtypes/rules/CaretValueRule.ts
+++ b/src/fshtypes/rules/CaretValueRule.ts
@@ -1,0 +1,11 @@
+import { Rule } from './Rule';
+import { FixedValueType } from './FixedValueRule';
+
+export class CaretValueRule extends Rule {
+  caretPath: string;
+  value: FixedValueType;
+
+  constructor(path: string) {
+    super(path);
+  }
+}

--- a/src/fshtypes/rules/index.ts
+++ b/src/fshtypes/rules/index.ts
@@ -5,3 +5,4 @@ export * from './OnlyRule';
 export * from './Rule';
 export * from './ValueSetRule';
 export * from './ContainsRule';
+export * from './CaretValueRule';

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -522,7 +522,7 @@ export class FSHImporter extends FSHVisitor {
   }
 
   visitCaretValueRule(ctx: pc.CaretValueRuleContext): CaretValueRule {
-    const path = ctx.path() ? this.visitPath(ctx.path()) : null;
+    const path = ctx.path() ? this.visitPath(ctx.path()) : '';
     const caretValueRule = new CaretValueRule(path)
       .withLocation(this.extractStartStop(ctx))
       .withFile(this.file);

--- a/src/import/parserContexts.ts
+++ b/src/import/parserContexts.ts
@@ -75,11 +75,15 @@ export interface SdRuleContext extends ParserRuleContext {
   containsRule(): ContainsRuleContext;
   onlyRule(): OnlyRuleContext;
   // obeysRule(): ObeysRuleContext;
-  // caretValueRule(): CaretValueRuleContext;
+  caretValueRule(): CaretValueRuleContext;
 }
 
 export interface PathContext extends ParserRuleContext {
   SEQUENCE(): ParserRuleContext;
+}
+
+export interface CaretPathContext extends ParserRuleContext {
+  CARET_SEQUENCE(): ParserRuleContext;
 }
 
 export interface PathsContext extends ParserRuleContext {
@@ -177,4 +181,10 @@ export interface OnlyRuleContext extends ParserRuleContext {
 export interface TargetTypeContext extends ParserRuleContext {
   SEQUENCE(): ParserRuleContext;
   REFERENCE(): ParserRuleContext;
+}
+
+export interface CaretValueRuleContext extends ParserRuleContext {
+  path(): PathContext;
+  caretPath(): CaretPathContext;
+  value(): ValueContext;
 }

--- a/test/fshtypes/rules/CaretValueRule.test.ts
+++ b/test/fshtypes/rules/CaretValueRule.test.ts
@@ -1,0 +1,13 @@
+import 'jest-extended';
+import { CaretValueRule } from '../../../src/fshtypes/rules/CaretValueRule';
+
+describe('CaretValueRule', () => {
+  describe('#constructor', () => {
+    it('should set the properties correctly', () => {
+      const c = new CaretValueRule('component.code');
+      expect(c.path).toBe('component.code');
+      expect(c.caretPath).toBeUndefined();
+      expect(c.value).toBeUndefined();
+    });
+  });
+});

--- a/test/import/FSHImporter.Extension.test.ts
+++ b/test/import/FSHImporter.Extension.test.ts
@@ -2,7 +2,8 @@ import {
   assertCardRule,
   assertFlagRule,
   assertOnlyRule,
-  assertValueSetRule
+  assertValueSetRule,
+  assertCaretValueRule
 } from '../utils/asserts';
 import { importText } from '../../src/import';
 
@@ -159,6 +160,21 @@ describe('FSHImporter', () => {
         const extension = result.extensions.get('SomeExtension');
         expect(extension.rules).toHaveLength(1);
         assertOnlyRule(extension.rules[0], 'value[x]', { type: 'Quantity' });
+      });
+    });
+
+    // Since Extensions use the same rule parsing code as Profiles, only do a minimal tests
+    describe('#caretValueRule', () => {
+      it('should parse a caret value rule with a path', () => {
+        const input = `
+        Extension: SomeExtension
+        * id ^short = "foo"
+        `;
+
+        const result = importText(input);
+        const extension = result.extensions.get('SomeExtension');
+        expect(extension.rules).toHaveLength(1);
+        assertCaretValueRule(extension.rules[0], 'id', 'short', 'foo');
       });
     });
   });

--- a/test/import/FSHImporter.Extension.test.ts
+++ b/test/import/FSHImporter.Extension.test.ts
@@ -80,7 +80,7 @@ describe('FSHImporter', () => {
       });
     });
 
-    // Since Extensions use the same rule parsing code as Profiles, only do a minimal tests
+    // Since Extensions use the same rule parsing code as Profiles, only do minimal tests of rules
     describe('#cardRule', () => {
       it('should parse simple card rules', () => {
         const input = `
@@ -112,7 +112,6 @@ describe('FSHImporter', () => {
       });
     });
 
-    // Since Extensions use the same rule parsing code as Profiles, only do a minimal tests
     describe('#flagRule', () => {
       it('should parse single-path single-value flag rules', () => {
         const input = `
@@ -127,7 +126,6 @@ describe('FSHImporter', () => {
       });
     });
 
-    // Since Extensions use the same rule parsing code as Profiles, only do a minimal tests
     describe('#valueSetRule', () => {
       it('should parse value set rules w/ names and strength', () => {
         const input = `
@@ -148,7 +146,6 @@ describe('FSHImporter', () => {
       });
     });
 
-    // Since Extensions use the same rule parsing code as Profiles, only do a minimal tests
     describe('#onlyRule', () => {
       it('should parse an only rule with one type', () => {
         const input = `
@@ -163,7 +160,6 @@ describe('FSHImporter', () => {
       });
     });
 
-    // Since Extensions use the same rule parsing code as Profiles, only do a minimal tests
     describe('#caretValueRule', () => {
       it('should parse a caret value rule with a path', () => {
         const input = `

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -804,11 +804,11 @@ describe('FSHImporter', () => {
         `;
         const result = importText(input);
         const profile = result.profiles.get('ObservationProfile');
-        assertCaretValueRule(profile.rules[0], null, 'description', 'foo');
-        assertCaretValueRule(profile.rules[1], null, 'experimental', false);
+        assertCaretValueRule(profile.rules[0], '', 'description', 'foo');
+        assertCaretValueRule(profile.rules[1], '', 'experimental', false);
         assertCaretValueRule(
           profile.rules[2],
-          null,
+          '',
           'keyword[0]',
           new FshCode('bar', 'foo', 'baz').withLocation([6, 25, 6, 37]).withFile('')
         );

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -4,7 +4,8 @@ import {
   assertFlagRule,
   assertOnlyRule,
   assertValueSetRule,
-  assertContainsRule
+  assertContainsRule,
+  assertCaretValueRule
 } from '../utils/asserts';
 import { importText } from '../../src/import';
 import { FshCode, FshQuantity, FshRatio } from '../../src/fshtypes';
@@ -728,86 +729,128 @@ describe('FSHImporter', () => {
         );
       });
     });
-  });
 
-  describe('#containsRule', () => {
-    it('should parse contains rule with one type', () => {
-      const input = `
-      Profile: ObservationProfile
-      Parent: Observation
-      * component contains SystolicBP 1..1
-      `;
+    describe('#containsRule', () => {
+      it('should parse contains rule with one type', () => {
+        const input = `
+        Profile: ObservationProfile
+        Parent: Observation
+        * component contains SystolicBP 1..1
+        `;
 
-      const result = importText(input);
-      const profile = result.profiles.get('ObservationProfile');
-      expect(profile.rules).toHaveLength(2);
-      assertContainsRule(profile.rules[0], 'component', 'SystolicBP');
-      assertCardRule(profile.rules[1], 'component[SystolicBP]', 1, 1);
+        const result = importText(input);
+        const profile = result.profiles.get('ObservationProfile');
+        expect(profile.rules).toHaveLength(2);
+        assertContainsRule(profile.rules[0], 'component', 'SystolicBP');
+        assertCardRule(profile.rules[1], 'component[SystolicBP]', 1, 1);
+      });
+
+      it('should parse contains rule with an alias', () => {
+        const input = `
+        Alias: FooBar = http://example.com
+        Profile: ObservationProfile
+        Parent: Observation
+        * component contains FooBar 1..1
+        `;
+
+        const result = importText(input);
+        const profile = result.profiles.get('ObservationProfile');
+        expect(profile.rules).toHaveLength(2);
+        assertContainsRule(profile.rules[0], 'component', 'http://example.com');
+        assertCardRule(profile.rules[1], 'component[http://example.com]', 1, 1);
+      });
+
+      it('should parse contains rules with multiple types', () => {
+        const input = `
+        Profile: ObservationProfile
+        Parent: Observation
+        * component contains SystolicBP 1..1 and DiastolicBP 2..*
+        `;
+
+        const result = importText(input);
+        const profile = result.profiles.get('ObservationProfile');
+        expect(profile.rules).toHaveLength(3);
+        assertContainsRule(profile.rules[0], 'component', 'SystolicBP', 'DiastolicBP');
+        assertCardRule(profile.rules[1], 'component[SystolicBP]', 1, 1);
+        assertCardRule(profile.rules[2], 'component[DiastolicBP]', 2, '*');
+      });
+
+      it('should parse contains rules with flags', () => {
+        const input = `
+        Profile: ObservationProfile
+        Parent: Observation
+        * component contains SystolicBP 1..1 MS and DiastolicBP 2..* MS SU
+        `;
+
+        const result = importText(input);
+        const profile = result.profiles.get('ObservationProfile');
+        expect(profile.rules).toHaveLength(5);
+        assertContainsRule(profile.rules[0], 'component', 'SystolicBP', 'DiastolicBP');
+        assertCardRule(profile.rules[1], 'component[SystolicBP]', 1, 1);
+        assertFlagRule(profile.rules[2], 'component[SystolicBP]', true, undefined, undefined);
+        assertCardRule(profile.rules[3], 'component[DiastolicBP]', 2, '*');
+        assertFlagRule(profile.rules[4], 'component[DiastolicBP]', true, true, undefined);
+      });
     });
 
-    it('should parse contains rule with an alias', () => {
-      const input = `
-      Alias: FooBar = http://example.com
-      Profile: ObservationProfile
-      Parent: Observation
-      * component contains FooBar 1..1
-      `;
+    describe('#caretValueRule', () => {
+      it('should parse caret value rules with no path', () => {
+        const input = `
+        Profile: ObservationProfile
+        Parent: Observation
+        * ^description = "foo"
+        * ^experimental = false
+        * ^keyword[0] = foo#bar "baz"
+        `;
+        const result = importText(input);
+        const profile = result.profiles.get('ObservationProfile');
+        assertCaretValueRule(profile.rules[0], null, 'description', 'foo');
+        assertCaretValueRule(profile.rules[1], null, 'experimental', false);
+        assertCaretValueRule(
+          profile.rules[2],
+          null,
+          'keyword[0]',
+          new FshCode('bar', 'foo', 'baz').withLocation([6, 25, 6, 37]).withFile('')
+        );
+      });
 
-      const result = importText(input);
-      const profile = result.profiles.get('ObservationProfile');
-      expect(profile.rules).toHaveLength(2);
-      assertContainsRule(profile.rules[0], 'component', 'http://example.com');
-      assertCardRule(profile.rules[1], 'component[http://example.com]', 1, 1);
+      it('should parse caret value rules with a path', () => {
+        const input = `
+        Profile: ObservationProfile
+        Parent: Observation
+        * status ^short = "foo"
+        * status ^sliceIsConstraining = false
+        * status ^code[0] = foo#bar "baz"
+        `;
+        const result = importText(input);
+        const profile = result.profiles.get('ObservationProfile');
+        assertCaretValueRule(profile.rules[0], 'status', 'short', 'foo');
+        assertCaretValueRule(profile.rules[1], 'status', 'sliceIsConstraining', false);
+        assertCaretValueRule(
+          profile.rules[2],
+          'status',
+          'code[0]',
+          new FshCode('bar', 'foo', 'baz').withLocation([6, 29, 6, 41]).withFile('')
+        );
+      });
     });
 
-    it('should parse contains rules with multiple types', () => {
-      const input = `
-      Profile: ObservationProfile
-      Parent: Observation
-      * component contains SystolicBP 1..1 and DiastolicBP 2..*
-      `;
-
-      const result = importText(input);
-      const profile = result.profiles.get('ObservationProfile');
-      expect(profile.rules).toHaveLength(3);
-      assertContainsRule(profile.rules[0], 'component', 'SystolicBP', 'DiastolicBP');
-      assertCardRule(profile.rules[1], 'component[SystolicBP]', 1, 1);
-      assertCardRule(profile.rules[2], 'component[DiastolicBP]', 2, '*');
-    });
-
-    it('should parse contains rules with flags', () => {
-      const input = `
-      Profile: ObservationProfile
-      Parent: Observation
-      * component contains SystolicBP 1..1 MS and DiastolicBP 2..* MS SU
-      `;
-
-      const result = importText(input);
-      const profile = result.profiles.get('ObservationProfile');
-      expect(profile.rules).toHaveLength(5);
-      assertContainsRule(profile.rules[0], 'component', 'SystolicBP', 'DiastolicBP');
-      assertCardRule(profile.rules[1], 'component[SystolicBP]', 1, 1);
-      assertFlagRule(profile.rules[2], 'component[SystolicBP]', true, undefined, undefined);
-      assertCardRule(profile.rules[3], 'component[DiastolicBP]', 2, '*');
-      assertFlagRule(profile.rules[4], 'component[DiastolicBP]', true, true, undefined);
-    });
-  });
-
-  describe('#obeysRule', () => {
-    // the current importer does not support obeys rule.
-    // this test should be removed once obeys rules are supported.
-    it('should issue a message when parsing an obeys rule', () => {
-      const input = `
-      Profile: ObservationProfile
-      Parent: Observation
-      * category obeys SomeInvariant
-      `;
-      const result = importText(input, 'Obeys.fsh');
-      const profile = result.profiles.get('ObservationProfile');
-      expect(profile.rules).toHaveLength(0);
-      expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-        /File: Obeys\.fsh.*Line 4\D.*Column 7\D.*Line 4\D.*Column 36\D/s
-      );
+    describe('#obeysRule', () => {
+      // the current importer does not support obeys rule.
+      // this test should be removed once obeys rules are supported.
+      it('should issue a message when parsing an obeys rule', () => {
+        const input = `
+        Profile: ObservationProfile
+        Parent: Observation
+        * category obeys SomeInvariant
+        `;
+        const result = importText(input, 'Obeys.fsh');
+        const profile = result.profiles.get('ObservationProfile');
+        expect(profile.rules).toHaveLength(0);
+        expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
+          /File: Obeys\.fsh.*Line 4\D.*Column 9\D.*Line 4\D.*Column 38\D/s
+        );
+      });
     });
   });
 });

--- a/test/utils/asserts.ts
+++ b/test/utils/asserts.ts
@@ -7,7 +7,8 @@ import {
   FixedValueType,
   OnlyRule,
   OnlyRuleType,
-  ContainsRule
+  ContainsRule,
+  CaretValueRule
 } from '../../src/fshtypes/rules';
 
 export function assertCardRule(rule: Rule, path: string, min: number, max: number | string): void {
@@ -66,4 +67,17 @@ export function assertContainsRule(rule: Rule, path: string, ...items: string[])
   expect(containsRule.path).toBe(path);
 
   expect(containsRule.items).toEqual(items);
+}
+
+export function assertCaretValueRule(
+  rule: Rule,
+  path: string,
+  caretPath: string,
+  value: FixedValueType
+): void {
+  expect(rule).toBeInstanceOf(CaretValueRule);
+  const caretValueRule = rule as CaretValueRule;
+  expect(caretValueRule.path).toBe(path);
+  expect(caretValueRule.caretPath).toBe(caretPath);
+  expect(caretValueRule.value).toEqual(value);
 }


### PR DESCRIPTION
This adds the `CaretValueRule` class, and the importing of the `CaretValueRule` class. This rule is used to read in rules like `* ^description = "foo"`, or `* status ^short = "foo"`. The path before the `^` is optional. For description of this syntax, see https://github.com/HL7/fhir-shorthand/wiki/2.2-Paths#addressing-structure-definition-attributes-directly.

Note that in `FSHImporter.Profile.test.ts`, the only relevant changes are the `CaretValueRule` tests. The other changes come from moving some other tests inside a block of code that I believe they should have been inside.