### PR TITLE
Unfolded elements should not cause diffs (plus other refactorings)

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -137,8 +137,6 @@ export class StructureDefinitionExporter {
       throw new ParentNotDefinedError(fshDefinition.name, parentName, fshDefinition.sourceInfo);
     }
 
-    // Capture the orginal elements so that any further changes are reflected in the differential
-    structDef.captureOriginalElements();
     this.setMetadata(structDef, fshDefinition);
     this.setRules(structDef, fshDefinition);
 

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1495,9 +1495,11 @@ export class ElementDefinition {
   /**
    * Instantiates a new ElementDefinition from a FHIR-conformant JSON representation
    * @param {Object} json - the FHIR-conformant JSON representation of the ElementDefinition to instantiate
+   * @param {captureOriginal} - indicate if original element should be captured for purposes of detecting
+   *   differential.  Defaults to true.
    * @returns {ElementDefinition} the ElementDefinition representing the data passed in
    */
-  static fromJSON(json: LooseElementDefJSON): ElementDefinition {
+  static fromJSON(json: LooseElementDefJSON, captureOriginal = true): ElementDefinition {
     const ed = new ElementDefinition();
     for (let prop of PROPS) {
       if (prop.endsWith('[x]')) {
@@ -1509,6 +1511,9 @@ export class ElementDefinition {
         // @ts-ignore
         ed[prop] = cloneDeep(json[prop]);
       }
+    }
+    if (captureOriginal) {
+      ed.captureOriginal();
     }
 
     return ed;

--- a/src/fhirtypes/ElementDefinition.ts
+++ b/src/fhirtypes/ElementDefinition.ts
@@ -1251,6 +1251,8 @@ export class ElementDefinition {
           const eClone = e.clone();
           eClone.id = eClone.id.replace(def.type, `${this.id}`);
           eClone.structDef = this.structDef;
+          // Capture the original so that diffs only show what changed *after* unfolding
+          eClone.captureOriginal();
           return eClone;
         });
         this.structDef.addElements(newElements);

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -289,9 +289,11 @@ export class StructureDefinition {
    * Constructs a new StructureDefinition representing the passed in JSON.  The JSON that is passed in must be a
    * properly formatted FHIR 3.0.1 StructureDefinition JSON.
    * @param {any} json - the FHIR 3.0.1 JSON representation of a StructureDefinition to construct
+   * @param {captureOriginalElements} - indicate if original elements should be captured for purposes of
+   *   detecting differentials.  Defaults to true.
    * @returns {StructureDefinition} a new StructureDefinition instance representing the passed in JSON
    */
-  static fromJSON(json: LooseStructDefJSON): StructureDefinition {
+  static fromJSON(json: LooseStructDefJSON, captureOriginalElements = true): StructureDefinition {
     const sd = new StructureDefinition();
     // First handle properties that are just straight translations from JSON
     for (const prop of PROPS) {
@@ -305,7 +307,7 @@ export class StructureDefinition {
     sd.elements.length = 0;
     if (json.snapshot && json.snapshot.element) {
       for (const el of json.snapshot.element) {
-        const ed = ElementDefinition.fromJSON(el);
+        const ed = ElementDefinition.fromJSON(el, captureOriginalElements);
         ed.structDef = sd;
         sd.elements.push(ed);
       }

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -58,10 +58,6 @@ export class StructureDefinition {
    */
   elements: ElementDefinition[];
 
-  /**
-   * A base clone of the Structure Definition from before any rules were applied
-   */
-  private _baseStructureDefinition: StructureDefinition;
   private _sdStructureDefinition: StructureDefinition;
 
   /**
@@ -77,13 +73,6 @@ export class StructureDefinition {
     root.isModifier = false;
     root.isSummary = false;
     this.elements = [root];
-  }
-
-  /**
-   * Get the base Structure Definition before any rules were applied
-   */
-  getBaseStructureDefinition() {
-    return this._baseStructureDefinition;
   }
 
   /**
@@ -312,8 +301,6 @@ export class StructureDefinition {
         sd.elements.push(ed);
       }
     }
-    // Keep a clone of the base structure definition for comparison once rules are applied
-    sd._baseStructureDefinition = cloneDeep(sd);
     return sd;
   }
 

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -671,4 +671,39 @@ describe('StructureDefinitionExporter', () => {
       min: 1
     });
   });
+
+  it('should correctly generate a diff containing only changed elements when elements are unfolded', () => {
+    // We already have separate tests for the differentials, so this just ensures that the
+    // StructureDefinition captures originals at the right time to produce the most correct
+    // differentials
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+
+    // Create a few rules that will force complex types to be "unfolded"
+    let rule = new CardRule('code.coding');
+    rule.min = 1;
+    rule.max = '*';
+    profile.rules.push(rule);
+
+    rule = new CardRule('code.coding.userSelected');
+    rule.min = 1;
+    rule.max = '1';
+    profile.rules.push(rule);
+
+    exporter.exportStructDef(profile);
+    const sd = exporter.structDefs[0];
+    const json = sd.toJSON();
+
+    expect(json.differential.element).toHaveLength(2);
+    expect(json.differential.element[0]).toEqual({
+      id: 'Observation.code.coding',
+      path: 'Observation.code.coding',
+      min: 1
+    });
+    expect(json.differential.element[1]).toEqual({
+      id: 'Observation.code.coding.userSelected',
+      path: 'Observation.code.coding.userSelected',
+      min: 1
+    });
+  });
 });

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -11,9 +11,12 @@ import {
   ContainsRule
 } from '../../src/fshtypes/rules';
 import { logger } from '../../src/utils/FSHLogger';
+import { getResolver } from '../utils/getResolver';
+import { ResolveFn } from '../../src/fhirtypes';
 
 describe('StructureDefinitionExporter', () => {
   let defs: FHIRDefinitions;
+  let resolve: ResolveFn;
   let doc: FSHDocument;
   let input: FSHTank;
   let exporter: StructureDefinitionExporter;
@@ -21,6 +24,7 @@ describe('StructureDefinitionExporter', () => {
 
   beforeAll(() => {
     defs = load('4.0.1');
+    resolve = getResolver(defs);
     mockWriter = jest.spyOn(logger.transports[0], 'write');
   });
 
@@ -181,7 +185,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Observation');
 
     const baseCard = baseStructDef.findElement('Observation.subject');
     const changedCard = sd.findElement('Observation.subject');
@@ -203,7 +207,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Observation');
 
     const baseCard = baseStructDef.findElement('Observation.status');
     const changedCard = sd.findElement('Observation.status');
@@ -229,7 +233,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('DiagnosticReport');
 
     const baseElement = baseStructDef.findElement('DiagnosticReport.conclusion');
     const changedElement = sd.findElement('DiagnosticReport.conclusion');
@@ -252,7 +256,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('DiagnosticReport');
 
     const baseElement = baseStructDef.findElement('DiagnosticReport.status');
     const changedElement = sd.findElement('DiagnosticReport.status');
@@ -277,7 +281,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('http://hl7.org/fhir/StructureDefinition/vitalsigns');
 
     const baseElement = baseStructDef.findElement('Observation.code');
     const changedElement = sd.findElement('Observation.code');
@@ -304,7 +308,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Appointment');
     const baseElement = baseStructDef.findElement('Appointment.description');
     const changedElement = sd.findElement('Appointment.description');
     expect(baseElement.binding).toBeUndefined();
@@ -323,7 +327,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Observation');
     const baseElement = baseStructDef.findElement('Observation.category');
     const changedElement = sd.findElement('Observation.category');
     expect(baseElement.binding.valueSet).toBe('http://hl7.org/fhir/ValueSet/observation-category');
@@ -343,7 +347,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Observation');
     const baseElement = baseStructDef.findElement('Observation.note');
     const changedElement = sd.findElement('Observation.note');
     expect(baseElement.binding).toBeUndefined();
@@ -364,7 +368,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Observation');
     const baseElement = baseStructDef.findElement('Observation.category');
     const changedElement = sd.findElement('Observation.category');
     expect(baseElement.binding.valueSet).toBe('http://hl7.org/fhir/ValueSet/observation-category');
@@ -389,7 +393,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Observation');
 
     const baseValue = baseStructDef.findElement('Observation.value[x]');
     const constrainedValue = sd.findElement('Observation.value[x]');
@@ -413,7 +417,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Observation');
 
     const baseSubject = baseStructDef.findElement('Observation.subject');
     const constrainedSubject = sd.findElement('Observation.subject');
@@ -452,7 +456,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(extension);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Extension');
 
     const baseValueX = baseStructDef.findElement('Extension.value[x]');
     const constrainedValueX = sd.findElement('Extension.value[x]');
@@ -487,7 +491,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Observation');
 
     const baseHasMember = baseStructDef.findElement('Observation.hasMember');
     const constrainedHasMember = sd.findElement('Observation.hasMember');
@@ -528,7 +532,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Observation');
 
     const baseValue = baseStructDef.findElement('Observation.value[x]');
     const constrainedValue = sd.findElement('Observation.value[x]');
@@ -552,7 +556,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Observation');
 
     const baseCode = baseStructDef.findElement('Observation.code');
     const fixedCode = sd.findElement('Observation.code');
@@ -573,7 +577,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Observation');
 
     const baseCode = baseStructDef.findElement('Observation.code');
     const fixedCode = sd.findElement('Observation.code');
@@ -596,7 +600,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('resprate');
 
     const barSlice = sd.elements.find(e => e.id === 'Observation.code.coding:barSlice');
 
@@ -617,7 +621,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('resprate');
 
     const barSlice = sd.elements.find(e => e.id === 'Observation.code.coding:barSlice');
     const fooSlice = sd.elements.find(e => e.id === 'Observation.code.coding:fooSlice');
@@ -637,7 +641,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('resprate');
 
     const barSlice = sd.elements.find(e => e.id === 'Observation.identifier:barSlice');
 

--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -17,7 +17,6 @@ describe('ElementDefinition', () => {
   });
   beforeEach(() => {
     observation = StructureDefinition.fromJSON(jsonObservation);
-    observation.captureOriginalElements();
     valueX = ElementDefinition.fromJSON(jsonValueX);
     valueX.structDef = observation;
   });
@@ -102,7 +101,8 @@ describe('ElementDefinition', () => {
 
   describe('#hasDiff', () => {
     it('should always show a diff for brand new elements w/ no original captured', () => {
-      expect(valueX.hasDiff()).toBeTruthy();
+      const newElement = new ElementDefinition('newElement');
+      expect(newElement.hasDiff()).toBeTruthy();
     });
 
     it('should not have a diff if nothing changes after capturing original', () => {
@@ -155,8 +155,11 @@ describe('ElementDefinition', () => {
 
   describe('#calculateDiff', () => {
     it('should have diff containing everything when there is no captured original', () => {
-      valueX.min = 1;
-      expect(valueX.calculateDiff()).toEqual(valueX);
+      const newElement = new ElementDefinition('newElement');
+      newElement.min = 0;
+      newElement.max = '1';
+      newElement.type = [{ code: 'string' }];
+      expect(newElement.calculateDiff()).toEqual(newElement);
     });
 
     it('should have a diff w/ only id and path when nothing changes after capturing original', () => {
@@ -287,7 +290,7 @@ describe('ElementDefinition', () => {
 
   describe('#clone', () => {
     it('should clone an element so that changes in the clone are not reflected in the original', () => {
-      const clone = valueX.clone();
+      const clone = valueX.clone(false);
       expect(clone).toEqual(valueX); // value-based equality (not sameness)
       clone.definition = 'I am a clone';
       expect(clone).not.toEqual(valueX);

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -59,7 +59,6 @@ describe('StructureDefinition', () => {
     });
 
     it('should reflect differentials for elements that changed after capturing originals', () => {
-      observation.captureOriginalElements();
       const code = observation.elements.find(e => e.id === 'Observation.code');
       code.short = 'Special observation code';
       const valueX = observation.elements.find(e => e.id === 'Observation.value[x]');


### PR DESCRIPTION
This PR contains three separate (but somewhat related) changes:

1. It modifies the behavior of the unfold function such that it captures the original elements right after unfolding.  This makes it so that a diff is only produced if something changes from the base definition.

2. It moves the invocation of captureElements into the SD and ED `fromJSON` functions, since it will almost always be wanted when deserializing from a JSON document.  An argument override can supress this behavior.

3. It removes a clone of the base SD that was not used in production code but served only to help in unit tests.