### PR TITLE
Add export of caretValueRule

### DIFF
--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -9,7 +9,8 @@ import {
   FlagRule,
   OnlyRule,
   ValueSetRule,
-  ContainsRule
+  ContainsRule,
+  CaretValueRule
 } from '../fshtypes/rules';
 import { logger } from '../utils/FSHLogger';
 import cloneDeep from 'lodash/cloneDeep';
@@ -80,6 +81,20 @@ export class StructureDefinitionExporter {
             element.bindToVS(rule.valueSet, rule.strength as ElementDefinitionBindingStrength);
           } else if (rule instanceof ContainsRule) {
             rule.items.forEach(item => element.addSlice(item));
+          } else if (rule instanceof CaretValueRule) {
+            if (rule.path !== '') {
+              element.setInstancePropertyByPath(
+                rule.caretPath,
+                rule.value,
+                this.resolve.bind(this)
+              );
+            } else {
+              structDef.setInstancePropertyByPath(
+                rule.caretPath,
+                rule.value,
+                this.resolve.bind(this)
+              );
+            }
           }
         } catch (e) {
           logger.error(e.message, rule.sourceInfo);

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -683,7 +683,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Observation');
 
     const status = sd.findElement('Observation.status');
     const baseStatus = baseStructDef.findElement('Observation.status');
@@ -719,7 +719,7 @@ describe('StructureDefinitionExporter', () => {
 
     exporter.exportStructDef(profile);
     const sd = exporter.structDefs[0];
-    const baseStructDef = sd.getBaseStructureDefinition();
+    const baseStructDef = resolve('Observation');
 
     expect(sd.description).toBe(baseStructDef.description);
     expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(

--- a/test/fhirtypes/ElementDefinition.test.ts
+++ b/test/fhirtypes/ElementDefinition.test.ts
@@ -24,6 +24,31 @@ describe('ElementDefinition', () => {
   describe('#fromJSON', () => {
     it('should load an element properly', () => {
       // Don't test everything, but get a sample anyway
+      expect(valueX.hasDiff()).toBeFalsy();
+      expect(valueX.id).toBe('Observation.value[x]');
+      expect(valueX.path).toBe('Observation.value[x]');
+      expect(valueX.min).toBe(0);
+      expect(valueX.max).toBe('1');
+      expect(valueX.type).toEqual([
+        { code: 'Quantity' },
+        { code: 'CodeableConcept' },
+        { code: 'string' },
+        { code: 'boolean' },
+        { code: 'integer' },
+        { code: 'Range' },
+        { code: 'Ratio' },
+        { code: 'SampledData' },
+        { code: 'time' },
+        { code: 'dateTime' },
+        { code: 'Period' }
+      ]);
+    });
+
+    it('should load an element properly without capturing original', () => {
+      const valueX = ElementDefinition.fromJSON(jsonValueX, false);
+      // Don't test everything, but get a sample anyway
+      expect(valueX.hasDiff()).toBeTruthy();
+      expect(valueX.calculateDiff()).toEqual(valueX);
       expect(valueX.id).toBe('Observation.value[x]');
       expect(valueX.path).toBe('Observation.value[x]');
       expect(valueX.min).toBe(0);

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -30,6 +30,40 @@ describe('StructureDefinition', () => {
       });
       expect(observation.elements).toHaveLength(50);
       const valueX = observation.elements[21];
+      expect(valueX.hasDiff()).toBeFalsy();
+      expect(valueX.id).toBe('Observation.value[x]');
+      expect(valueX.path).toBe('Observation.value[x]');
+      expect(valueX.min).toBe(0);
+      expect(valueX.max).toBe('1');
+      expect(valueX.type).toEqual([
+        { code: 'Quantity' },
+        { code: 'CodeableConcept' },
+        { code: 'string' },
+        { code: 'boolean' },
+        { code: 'integer' },
+        { code: 'Range' },
+        { code: 'Ratio' },
+        { code: 'SampledData' },
+        { code: 'time' },
+        { code: 'dateTime' },
+        { code: 'Period' }
+      ]);
+    });
+
+    it('should load a resource properly without capturing originals', () => {
+      observation = StructureDefinition.fromJSON(jsonObservation, false);
+      // Don't test everything, but get a sample anyway
+      expect(observation.id).toBe('Observation');
+      expect(observation.meta.lastUpdated).toBe('2019-11-01T09:29:23.356+11:00');
+      expect(observation.extension).toHaveLength(6);
+      expect(observation.extension[0]).toEqual({
+        url: 'http://hl7.org/fhir/StructureDefinition/structuredefinition-category',
+        valueString: 'Clinical.Diagnostics'
+      });
+      expect(observation.elements).toHaveLength(50);
+      const valueX = observation.elements[21];
+      expect(valueX.hasDiff()).toBeTruthy();
+      expect(valueX.calculateDiff()).toEqual(valueX);
       expect(valueX.id).toBe('Observation.value[x]');
       expect(valueX.path).toBe('Observation.value[x]');
       expect(valueX.min).toBe(0);


### PR DESCRIPTION
This adds exporting of `caretValueRule`. This exporting can operate on an individual `ElementDefinition`, or a `StructureDefinition` itself. Also adds tests of this exporting on the `StructureDefinitionExporter`.