### PR TITLE
Add source information to metadata log statements

### DIFF
--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -129,7 +129,7 @@ export class FSHImporter extends FSHVisitor {
   ): void {
     const seenPairs: Map<SdMetadataKey, string> = new Map();
     metaCtx
-      .map(sdMeta => Object.assign(this.visitSdMetadata(sdMeta), { context: sdMeta }))
+      .map(sdMeta => ({ ...this.visitSdMetadata(sdMeta), context: sdMeta }))
       .forEach(pair => {
         if (seenPairs.has(pair.key)) {
           logger.error(
@@ -175,9 +175,10 @@ export class FSHImporter extends FSHVisitor {
   ): void {
     const seenPairs: Map<InstanceMetadataKey, string> = new Map();
     metaCtx
-      .map(instanceMetadata =>
-        Object.assign(this.visitInstanceMetadata(instanceMetadata), { context: instanceMetadata })
-      )
+      .map(instanceMetadata => ({
+        ...this.visitInstanceMetadata(instanceMetadata),
+        context: instanceMetadata
+      }))
       .forEach(pair => {
         if (seenPairs.has(pair.key)) {
           logger.error(

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -129,11 +129,14 @@ export class FSHImporter extends FSHVisitor {
   ): void {
     const seenPairs: Map<SdMetadataKey, string> = new Map();
     metaCtx
-      .map(sdMeta => this.visitSdMetadata(sdMeta))
+      .map(sdMeta => Object.assign(this.visitSdMetadata(sdMeta), { context: sdMeta }))
       .forEach(pair => {
         if (seenPairs.has(pair.key)) {
           logger.error(
-            `Metadata field '${pair.key}' already declared with value '${seenPairs.get(pair.key)}'.`
+            `Metadata field '${pair.key}' already declared with value '${seenPairs.get(
+              pair.key
+            )}'.`,
+            { file: this.file, location: this.extractStartStop(pair.context) }
           );
           return;
         }
@@ -161,7 +164,7 @@ export class FSHImporter extends FSHVisitor {
       this.parseInstance(instance, ctx.instanceMetadata(), ctx.fixedValueRule());
       this.doc.instances.set(instance.name, instance);
     } catch (e) {
-      logger.error(e.message);
+      logger.error(e.message, instance.sourceInfo);
     }
   }
 
@@ -172,11 +175,16 @@ export class FSHImporter extends FSHVisitor {
   ): void {
     const seenPairs: Map<InstanceMetadataKey, string> = new Map();
     metaCtx
-      .map(instanceMetadata => this.visitInstanceMetadata(instanceMetadata))
+      .map(instanceMetadata =>
+        Object.assign(this.visitInstanceMetadata(instanceMetadata), { context: instanceMetadata })
+      )
       .forEach(pair => {
         if (seenPairs.has(pair.key)) {
           logger.error(
-            `Metadata field '${pair.key}' already declared with value '${seenPairs.get(pair.key)}'.`
+            `Metadata field '${pair.key}' already declared with value '${seenPairs.get(
+              pair.key
+            )}'.`,
+            { file: this.file, location: this.extractStartStop(pair.context) }
           );
           return;
         }

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -141,6 +141,26 @@ describe('FSHImporter', () => {
         expect(profile.title).toBe('An Observation Profile');
         expect(profile.description).toBe('A profile on Observation');
       });
+
+      it('should log an error when encountering a duplicate metadata attribute', () => {
+        const input = `
+        Profile: ObservationProfile
+        Parent: Observation
+        Id: observation-profile
+        Title: "An Observation Profile"
+        Description: "A profile on Observation"
+        Title: "Duplicate Observation Profile"
+        Description: "A duplicated profile on Observation"
+        `;
+
+        importText(input, 'Dupe.fsh');
+        expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 2][0].message).toMatch(
+          /File: Dupe\.fsh.*Line 7\D.*Column 9\D.*Line 7\D.*Column 46\D/s
+        );
+        expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
+          /File: Dupe\.fsh.*Line 8\D.*Column 9\D.*Line 8\D.*Column 58\D/s
+        );
+      });
     });
 
     describe('#cardRule', () => {


### PR DESCRIPTION
Logger errors may be written when parsing profiles, extensions, and
instances. Duplicated metadata elements will show the source
location of the second (or third, etc.) of the element. Missing
metadata for an instance will show the instance's source location.

With the changes in this pull request, all currently logged errors that could include source information will include it.