### PR TITLE
Report errors from antlr through logger

### DIFF
--- a/src/import/FSHErrorListener.ts
+++ b/src/import/FSHErrorListener.ts
@@ -1,0 +1,27 @@
+import { ErrorListener } from 'antlr4/error';
+import { logger } from '../utils/FSHLogger';
+import { Recognizer, Token } from 'antlr4';
+
+export class FSHErrorListener extends ErrorListener {
+  constructor(readonly file: string) {
+    super();
+  }
+
+  syntaxError(
+    recognizer: Recognizer,
+    offendingSymbol: Token,
+    line: number,
+    column: number,
+    msg: string
+  ): void {
+    logger.error(msg, {
+      file: this.file,
+      location: {
+        startLine: line,
+        startColumn: column + 1,
+        endLine: line,
+        endColumn: column + offendingSymbol.text.length
+      }
+    });
+  }
+}

--- a/src/import/importText.ts
+++ b/src/import/importText.ts
@@ -4,6 +4,7 @@ import { FSHParser } from './generated/FSHParser';
 import { DocContext } from './parserContexts';
 import { FSHImporter } from './FSHImporter';
 import { FSHDocument } from './FSHDocument';
+import { FSHErrorListener } from './FSHErrorListener';
 
 /**
  * Parses a text string as a FSHDocument.
@@ -13,16 +14,25 @@ import { FSHDocument } from './FSHDocument';
  */
 export function importText(text: string, file?: string): FSHDocument {
   const importer = new FSHImporter(file);
-  return importer.visitDoc(parseDoc(text));
+  return importer.visitDoc(parseDoc(text, file));
 }
 
 // NOTE: Since the ANTLR parser/lexer is JS (not typescript), we need to use some ts-ignore here.
-function parseDoc(input: string): DocContext {
+function parseDoc(input: string, file?: string): DocContext {
   const chars = new InputStream(input);
   const lexer = new FSHLexer(chars);
+  const listener = new FSHErrorListener(file);
+  // @ts-ignore
+  lexer.removeErrorListeners();
+  // @ts-ignore
+  lexer.addErrorListener(listener);
   // @ts-ignore
   const tokens = new CommonTokenStream(lexer);
   const parser = new FSHParser(tokens);
+  // @ts-ignore
+  parser.removeErrorListeners();
+  // @ts-ignore
+  parser.addErrorListener(listener);
   // @ts-ignore
   parser.buildParseTrees = true;
   // @ts-ignore


### PR DESCRIPTION
Mismatched or extraneous input encountered during parsing will
produce error messages that include the location of the error.
Two tests are added to FSHImporter.test.ts for these errors.

This pull request addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-166.