### PR TITLE
Slice Extension in ContainsRule

### DIFF
--- a/src/errors/InvalidExtensionSliceError.ts
+++ b/src/errors/InvalidExtensionSliceError.ts
@@ -1,0 +1,10 @@
+import { Annotated } from './Annotated';
+
+export class InvalidExtensionSliceError extends Error implements Annotated {
+  specReferences = ['http://www.hl7.org/fhiR/profiling.html#slicing'];
+  constructor(public sliceName: string) {
+    super(
+      `The slice ${sliceName} on extension must reference an existing extension, or fix a url if the extension is defined inline.`
+    );
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -22,3 +22,5 @@ export * from './CannotResolvePathError';
 export * from './InvalidElementAccessError';
 export * from './InvalidSumOfSliceMinsError';
 export * from './InvalidMaxOfSliceError';
+export * from './InvalidExtensionSliceError';
+export * from './ParentNotDefinedError';

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -2,7 +2,7 @@ import { FHIRDefinitions } from '../fhirdefs';
 import { StructureDefinition, ElementDefinitionBindingStrength } from '../fhirtypes';
 import { Profile, Extension } from '../fshtypes';
 import { FSHTank } from '../import';
-import { ParentNotDefinedError } from '../errors/ParentNotDefinedError';
+import { ParentNotDefinedError, InvalidExtensionSliceError } from '../errors';
 import {
   CardRule,
   FixedValueRule,
@@ -89,7 +89,9 @@ export class StructureDefinitionExporter {
               if (isExtension) {
                 const extension = this.resolve(item);
                 if (extension) {
-                  if (!slice.type[0].profile) slice.type[0].profile = [];
+                  if (!slice.type[0].profile) {
+                    slice.type[0].profile = [];
+                  }
                   slice.type[0].profile.push(extension.url);
                 }
               }
@@ -122,17 +124,41 @@ export class StructureDefinitionExporter {
   }
 
   /**
+   * Does post processing validation on the sd
+   * @param {StructureDefinition} structDef - The sd to validate
+   * @throws {InvalidExtensionSliceError} when the sd contains an extension with invalid slices
+   */
+  private validateStructureDefinition(structDef: StructureDefinition): void {
+    // Need to check that extensions define a URL correctly
+    const extensionSlices = structDef.elements.filter(
+      e => e.path.endsWith('extension') && e.sliceName
+    );
+    extensionSlices?.forEach(ext => {
+      const profileUrl =
+        ext.type?.length > 0 && ext.type[0].profile?.length > 0 && ext.type[0].profile[0];
+      const urlChild = ext.children().find(c => c.id === `${ext.id}.url`);
+      // If an element is a slice of extension, it should have a url in type, or a fixedUri
+      if (!profileUrl && !urlChild?.fixedUri) {
+        throw new InvalidExtensionSliceError(ext.sliceName);
+      }
+    });
+  }
+
+  /**
    * Looks through FHIR definitions to find the definition of the passed-in type
    * @param {string} type - The type to search for the FHIR definition of
    * @returns {StructureDefinition | undefined}
    */
   private resolve(type: string): StructureDefinition | undefined {
+    type = this.tank.resolveAlias(type);
     const json = this.FHIRDefs.find(type);
     if (json) {
       return StructureDefinition.fromJSON(json);
       // Maybe it's a FSH-defined definition and not a FHIR one
     } else {
-      let structDef = cloneDeep(this.structDefs.find(sd => sd.name === type));
+      let structDef = cloneDeep(
+        this.structDefs.find(sd => sd.name === type || sd.id === type || sd.url === type)
+      );
       if (!structDef) {
         // If we find a parent, then we can export and resolve for its type again
         const parentDefinition = this.tank.findProfile(type) ?? this.tank.findExtension(type);
@@ -166,6 +192,7 @@ export class StructureDefinitionExporter {
 
     this.setMetadata(structDef, fshDefinition);
     this.setRules(structDef, fshDefinition);
+    this.validateStructureDefinition(structDef);
 
     this.structDefs.push(structDef);
   }

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -133,7 +133,7 @@ export class StructureDefinitionExporter {
     const extensionSlices = structDef.elements.filter(
       e => e.path.endsWith('extension') && e.sliceName
     );
-    extensionSlices?.forEach(ext => {
+    extensionSlices.forEach(ext => {
       const profileUrl =
         ext.type?.length > 0 && ext.type[0].profile?.length > 0 && ext.type[0].profile[0];
       const urlChild = ext.children().find(c => c.id === `${ext.id}.url`);
@@ -150,7 +150,8 @@ export class StructureDefinitionExporter {
    * @returns {StructureDefinition | undefined}
    */
   private resolve(type: string): StructureDefinition | undefined {
-    type = this.tank.resolveAlias(type);
+    const alias = this.tank.resolveAlias(type);
+    type = alias ? alias : type;
     const json = this.FHIRDefs.find(type);
     if (json) {
       return StructureDefinition.fromJSON(json);

--- a/src/export/StructureDefinitionExporter.ts
+++ b/src/export/StructureDefinitionExporter.ts
@@ -135,11 +135,10 @@ export class StructureDefinitionExporter {
       let structDef = cloneDeep(this.structDefs.find(sd => sd.name === type));
       if (!structDef) {
         // If we find a parent, then we can export and resolve for its type again
-        const parentDefinition =
-          this.tank.findProfileByName(type) ?? this.tank.findExtensionByName(type);
+        const parentDefinition = this.tank.findProfile(type) ?? this.tank.findExtension(type);
         if (parentDefinition) {
           this.exportStructDef(parentDefinition);
-          structDef = this.resolve(type);
+          structDef = this.resolve(parentDefinition.name);
         }
       }
       return structDef;

--- a/src/fhirdefs/FHIRDefinitions.ts
+++ b/src/fhirdefs/FHIRDefinitions.ts
@@ -90,6 +90,9 @@ function addDefinitionToMap(def: any, defMap: Map<string, any>): void {
   if (def.url) {
     defMap.set(def.url, def);
   }
+  if (def.name) {
+    defMap.set(def.name, def);
+  }
 }
 
 function cloneJsonMapValues(map: Map<string, any>): any {

--- a/src/import/FSHImporter.ts
+++ b/src/import/FSHImporter.ts
@@ -508,7 +508,7 @@ export class FSHImporter extends FSHVisitor {
 
     rules.push(containsRule);
     ctx.item().forEach(i => {
-      const item = this.aliasAwareValue(i.SEQUENCE().getText());
+      const item = i.SEQUENCE().getText();
       containsRule.items.push(item);
 
       const cardRule = new CardRule(`${containsRule.path}[${item}]`)

--- a/src/import/FSHTank.ts
+++ b/src/import/FSHTank.ts
@@ -27,12 +27,7 @@ export class FSHTank {
    * @returns {Profile | undefined}
    */
   public findProfile(key: string): Profile | undefined {
-    let profile = this.getAllProfiles().find(p => p.name === key || p.id === key);
-    if (!profile) {
-      const aliased = this.findAlias(key);
-      if (aliased) profile = this.getAllProfiles().find(p => p.name === key || p.id === key);
-    }
-    return profile;
+    return this.getAllProfiles().find(p => p.name === key || p.id === key);
   }
 
   /**
@@ -41,13 +36,7 @@ export class FSHTank {
    * @returns {[Extension, string]}
    */
   public findExtension(key: string): Extension | undefined {
-    let extension = this.getAllExtensions().find(p => p.name === key || p.id === key);
-    if (!extension) {
-      const aliased = this.findAlias(key);
-      if (aliased)
-        extension = this.getAllExtensions().find(p => p.name === aliased || p.id === aliased);
-    }
-    return extension;
+    return this.getAllExtensions().find(p => p.name === key || p.id === key);
   }
 
   /**
@@ -55,10 +44,11 @@ export class FSHTank {
    * @param {string} name - The name of the alias we're looking for
    * @returns {string | undefined}
    */
-  public findAlias(name: string): string | undefined {
+  public resolveAlias(name: string): string | undefined {
     for (const doc of this.docs) {
       const foundAlias = doc.aliases.get(name);
       if (foundAlias) return foundAlias;
     }
+    return name;
   }
 }

--- a/src/import/FSHTank.ts
+++ b/src/import/FSHTank.ts
@@ -22,20 +22,43 @@ export class FSHTank {
   }
 
   /**
-   * Finds the profile in the tank by name, if it exists
-   * @param {string} name - The name of the profile we're looking for
+   * Finds the profile in the tank by name, id, or alias, if it exists
+   * @param {string} key - The name or id of the profile we're looking for
    * @returns {Profile | undefined}
    */
-  public findProfileByName(name: string): Profile | undefined {
-    return this.getAllProfiles().find(profile => profile.name === name);
+  public findProfile(key: string): Profile | undefined {
+    let profile = this.getAllProfiles().find(p => p.name === key || p.id === key);
+    if (!profile) {
+      const aliased = this.findAlias(key);
+      if (aliased) profile = this.getAllProfiles().find(p => p.name === key || p.id === key);
+    }
+    return profile;
   }
 
   /**
-   * Finds the extension in the tank by name, if it exists
-   * @param {string} name - The name of the extension we're looking for
-   * @returns {Extension | undefined}
+   * Finds the extension in the tank by name, id, or alias, if it exists
+   * @param {string} key - The name or id of the extension we're looking for
+   * @returns {[Extension, string]}
    */
-  public findExtensionByName(name: string): Extension | undefined {
-    return this.getAllExtensions().find(extension => extension.name === name);
+  public findExtension(key: string): Extension | undefined {
+    let extension = this.getAllExtensions().find(p => p.name === key || p.id === key);
+    if (!extension) {
+      const aliased = this.findAlias(key);
+      if (aliased)
+        extension = this.getAllExtensions().find(p => p.name === aliased || p.id === aliased);
+    }
+    return extension;
+  }
+
+  /**
+   * Finds the alias in the tank, if it exists
+   * @param {string} name - The name of the alias we're looking for
+   * @returns {string | undefined}
+   */
+  public findAlias(name: string): string | undefined {
+    for (const doc of this.docs) {
+      const foundAlias = doc.aliases.get(name);
+      if (foundAlias) return foundAlias;
+    }
   }
 }

--- a/src/import/FSHTank.ts
+++ b/src/import/FSHTank.ts
@@ -27,7 +27,12 @@ export class FSHTank {
    * @returns {Profile | undefined}
    */
   public findProfile(key: string): Profile | undefined {
-    return this.getAllProfiles().find(p => p.name === key || p.id === key);
+    return this.getAllProfiles().find(
+      p =>
+        p.name === key ||
+        p.id === key ||
+        `${this.config.canonical}/StructureDefinition/${p.id}` === key
+    );
   }
 
   /**
@@ -36,7 +41,12 @@ export class FSHTank {
    * @returns {[Extension, string]}
    */
   public findExtension(key: string): Extension | undefined {
-    return this.getAllExtensions().find(p => p.name === key || p.id === key);
+    return this.getAllExtensions().find(
+      p =>
+        p.name === key ||
+        p.id === key ||
+        `${this.config.canonical}/StructureDefinition/${p.id}` === key
+    );
   }
 
   /**
@@ -49,6 +59,6 @@ export class FSHTank {
       const foundAlias = doc.aliases.get(name);
       if (foundAlias) return foundAlias;
     }
-    return name;
+    return undefined;
   }
 }

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -635,6 +635,32 @@ describe('StructureDefinitionExporter', () => {
     });
   });
 
+  it('should apply a ContainsRule of a defined extension on a modifierExtension element', () => {
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+
+    const rule = new ContainsRule('modifierExtension');
+    rule.items = ['valueset-expression'];
+    profile.rules.push(rule);
+
+    exporter.exportStructDef(profile);
+    const sd = exporter.structDefs[0];
+
+    const extension = sd.elements.find(e => e.id === 'Observation.modifierExtension');
+    const valuesetExpression = sd.elements.find(
+      e => e.id === 'Observation.modifierExtension:valueset-expression'
+    );
+
+    expect(extension.slicing).toBeDefined();
+    expect(extension.slicing.discriminator.length).toBe(1);
+    expect(extension.slicing.discriminator[0]).toEqual({ type: 'value', path: 'url' });
+    expect(valuesetExpression).toBeDefined();
+    expect(valuesetExpression.type[0]).toEqual({
+      code: 'Extension',
+      profile: ['http://hl7.org/fhir/StructureDefinition/valueset-expression']
+    });
+  });
+
   it('should apply a ContainsRule of an undefined extension on an extension element', () => {
     const profile = new Profile('Foo');
     profile.parent = 'Observation';

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -609,6 +609,53 @@ describe('StructureDefinitionExporter', () => {
     expect(barSlice).toBeDefined();
   });
 
+  it('should apply a ContainsRule of a defined extension on an extension element', () => {
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+
+    const rule = new ContainsRule('extension');
+    rule.items = ['valueset-expression'];
+    profile.rules.push(rule);
+
+    exporter.exportStructDef(profile);
+    const sd = exporter.structDefs[0];
+
+    const extension = sd.elements.find(e => e.id === 'Observation.extension');
+    const valuesetExpression = sd.elements.find(
+      e => e.id === 'Observation.extension:valueset-expression'
+    );
+
+    expect(extension.slicing).toBeDefined();
+    expect(extension.slicing.discriminator.length).toBe(1);
+    expect(extension.slicing.discriminator[0]).toEqual({ type: 'value', path: 'url' });
+    expect(valuesetExpression).toBeDefined();
+    expect(valuesetExpression.type[0]).toEqual({
+      code: 'Extension',
+      profile: ['http://hl7.org/fhir/StructureDefinition/valueset-expression']
+    });
+  });
+
+  it('should apply a ContainsRule of an undefined extension on an extension element', () => {
+    const profile = new Profile('Foo');
+    profile.parent = 'Observation';
+
+    const rule = new ContainsRule('extension');
+    rule.items = ['foo'];
+    profile.rules.push(rule);
+
+    exporter.exportStructDef(profile);
+    const sd = exporter.structDefs[0];
+
+    const extension = sd.elements.find(e => e.id === 'Observation.extension');
+    const foo = sd.elements.find(e => e.id === 'Observation.extension:foo');
+
+    expect(extension.slicing).toBeDefined();
+    expect(extension.slicing.discriminator.length).toBe(1);
+    expect(extension.slicing.discriminator[0]).toEqual({ type: 'value', path: 'url' });
+    expect(foo).toBeDefined();
+    expect(foo.type[0]).toEqual({ code: 'Extension' });
+  });
+
   it('should apply multiple ContainsRule on an element with defined slicing', () => {
     const profile = new Profile('Foo');
     profile.parent = 'resprate';

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -765,21 +765,6 @@ describe('FSHImporter', () => {
         assertCardRule(profile.rules[1], 'component[SystolicBP]', 1, 1);
       });
 
-      it('should parse contains rule with an alias', () => {
-        const input = `
-        Alias: FooBar = http://example.com
-        Profile: ObservationProfile
-        Parent: Observation
-        * component contains FooBar 1..1
-        `;
-
-        const result = importText(input);
-        const profile = result.profiles.get('ObservationProfile');
-        expect(profile.rules).toHaveLength(2);
-        assertContainsRule(profile.rules[0], 'component', 'http://example.com');
-        assertCardRule(profile.rules[1], 'component[http://example.com]', 1, 1);
-      });
-
       it('should parse contains rules with multiple types', () => {
         const input = `
         Profile: ObservationProfile


### PR DESCRIPTION
Now when an extension element is sliced by a `ContainsRule`, if no slicing exists on the element, a slicing is added to the `ElementDefinition`. After the extension slice is added, if the extension is already defined and can be resolved, the canonical url of the extension is added to the `type.profile` on the extension `ElementDefinition`.

This addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-168.