### PR TITLE
Add LoggerSpy class and use in tests

### DIFF
--- a/test/export/ExtensionExporter.test.ts
+++ b/test/export/ExtensionExporter.test.ts
@@ -3,17 +3,17 @@ import { FSHTank, FSHDocument } from '../../src/import';
 import { FHIRDefinitions, load } from '../../src/fhirdefs';
 import { Extension } from '../../src/fshtypes';
 import { logger } from '../../src/utils/FSHLogger';
+import { LoggerSpy } from '../testhelpers/loggerSpy';
 
 describe('ExtensionExporter', () => {
   let defs: FHIRDefinitions;
   let doc: FSHDocument;
   let input: FSHTank;
   let exporter: ExtensionExporter;
-  let mockWriter: jest.SpyInstance<boolean, [any, string, ((error: Error) => void)?]>;
+  const loggerSpy = new LoggerSpy(logger);
 
   beforeAll(() => {
     defs = load('4.0.1');
-    mockWriter = jest.spyOn(logger.transports[0], 'write');
   });
 
   beforeEach(() => {
@@ -59,9 +59,7 @@ describe('ExtensionExporter', () => {
     extension.parent = 'DoesNotExist';
     doc.extensions.set(extension.name, extension);
     exporter.export();
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: Wrong\.fsh.*Line: 14 - 24\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: Wrong\.fsh.*Line: 14 - 24\D/s);
   });
 
   it('should export extensions with FSHy parents', () => {

--- a/test/export/ExtensionExporter.test.ts
+++ b/test/export/ExtensionExporter.test.ts
@@ -2,15 +2,13 @@ import { ExtensionExporter } from '../../src/export';
 import { FSHTank, FSHDocument } from '../../src/import';
 import { FHIRDefinitions, load } from '../../src/fhirdefs';
 import { Extension } from '../../src/fshtypes';
-import { logger } from '../../src/utils/FSHLogger';
-import { LoggerSpy } from '../testhelpers/loggerSpy';
+import { loggerSpy } from '../testhelpers/loggerSpy';
 
 describe('ExtensionExporter', () => {
   let defs: FHIRDefinitions;
   let doc: FSHDocument;
   let input: FSHTank;
   let exporter: ExtensionExporter;
-  const loggerSpy = new LoggerSpy(logger);
 
   beforeAll(() => {
     defs = load('4.0.1');

--- a/test/export/ProfileExporter.test.ts
+++ b/test/export/ProfileExporter.test.ts
@@ -2,15 +2,13 @@ import { ProfileExporter } from '../../src/export';
 import { FSHTank, FSHDocument } from '../../src/import';
 import { FHIRDefinitions, load } from '../../src/fhirdefs';
 import { Profile } from '../../src/fshtypes';
-import { logger } from '../../src/utils/FSHLogger';
-import { LoggerSpy } from '../testhelpers/loggerSpy';
+import { loggerSpy } from '../testhelpers/loggerSpy';
 
 describe('ProfileExporter', () => {
   let defs: FHIRDefinitions;
   let doc: FSHDocument;
   let input: FSHTank;
   let exporter: ProfileExporter;
-  const loggerSpy = new LoggerSpy(logger);
 
   beforeAll(() => {
     defs = load('4.0.1');

--- a/test/export/ProfileExporter.test.ts
+++ b/test/export/ProfileExporter.test.ts
@@ -3,17 +3,17 @@ import { FSHTank, FSHDocument } from '../../src/import';
 import { FHIRDefinitions, load } from '../../src/fhirdefs';
 import { Profile } from '../../src/fshtypes';
 import { logger } from '../../src/utils/FSHLogger';
+import { LoggerSpy } from '../testhelpers/loggerSpy';
 
 describe('ProfileExporter', () => {
   let defs: FHIRDefinitions;
   let doc: FSHDocument;
   let input: FSHTank;
   let exporter: ProfileExporter;
-  let mockWriter: jest.SpyInstance<boolean, [any, string, ((error: Error) => void)?]>;
+  const loggerSpy = new LoggerSpy(logger);
 
   beforeAll(() => {
     defs = load('4.0.1');
-    mockWriter = jest.spyOn(logger.transports[0], 'write');
   });
 
   beforeEach(() => {
@@ -59,9 +59,7 @@ describe('ProfileExporter', () => {
     profile.parent = 'BogusParent';
     doc.profiles.set(profile.name, profile);
     exporter.export();
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: Bogus\.fsh.*Line: 2 - 4\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: Bogus\.fsh.*Line: 2 - 4\D/s);
   });
 
   it('should export profiles with FSHy parents', () => {

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -11,8 +11,7 @@ import {
   ContainsRule,
   CaretValueRule
 } from '../../src/fshtypes/rules';
-import { logger } from '../../src/utils/FSHLogger';
-import { LoggerSpy } from '../testhelpers/loggerSpy';
+import { loggerSpy } from '../testhelpers/loggerSpy';
 import { getResolver } from '../testhelpers/getResolver';
 import { ResolveFn } from '../../src/fhirtypes';
 
@@ -22,7 +21,6 @@ describe('StructureDefinitionExporter', () => {
   let doc: FSHDocument;
   let input: FSHTank;
   let exporter: StructureDefinitionExporter;
-  const loggerSpy = new LoggerSpy(logger);
 
   beforeAll(() => {
     defs = load('4.0.1');

--- a/test/export/StructureDefinitionExporter.test.ts
+++ b/test/export/StructureDefinitionExporter.test.ts
@@ -12,6 +12,7 @@ import {
   CaretValueRule
 } from '../../src/fshtypes/rules';
 import { logger } from '../../src/utils/FSHLogger';
+import { LoggerSpy } from '../testhelpers/loggerSpy';
 import { getResolver } from '../testhelpers/getResolver';
 import { ResolveFn } from '../../src/fhirtypes';
 
@@ -21,12 +22,11 @@ describe('StructureDefinitionExporter', () => {
   let doc: FSHDocument;
   let input: FSHTank;
   let exporter: StructureDefinitionExporter;
-  let mockWriter: jest.SpyInstance<boolean, [any, string, ((error: Error) => void)?]>;
+  const loggerSpy = new LoggerSpy(logger);
 
   beforeAll(() => {
     defs = load('4.0.1');
     resolve = getResolver(defs);
-    mockWriter = jest.spyOn(logger.transports[0], 'write');
   });
 
   beforeEach(() => {
@@ -169,9 +169,7 @@ describe('StructureDefinitionExporter', () => {
     const structDef = exporter.structDefs[0];
     expect(structDef).toBeDefined();
     expect(structDef.type).toBe('Resource');
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: Foo\.fsh.*Line: 3 - 4\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: Foo\.fsh.*Line: 3 - 4\D/s);
   });
 
   // Card Rule
@@ -217,9 +215,7 @@ describe('StructureDefinitionExporter', () => {
     expect(baseCard.max).toBe('1');
     expect(changedCard.min).toBe(1);
     expect(changedCard.max).toBe('1');
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: Wrong\.fsh.*Line: 5\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: Wrong\.fsh.*Line: 5\D/s);
   });
 
   // Flag Rule
@@ -265,9 +261,7 @@ describe('StructureDefinitionExporter', () => {
     expect(baseElement.mustSupport).toBeFalsy();
     expect(changedElement.isModifier).toBe(true);
     expect(changedElement.mustSupport).toBeFalsy();
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: Nope\.fsh.*Line: 8\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: Nope\.fsh.*Line: 8\D/s);
   });
 
   it('should not apply a flag rule that disables mustSupport', () => {
@@ -292,9 +286,7 @@ describe('StructureDefinitionExporter', () => {
     expect(changedElement.isModifier).toBeFalsy();
     expect(changedElement.isSummary).toBe(true);
     expect(changedElement.mustSupport).toBe(true);
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: Nope\.fsh.*Line: 8\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: Nope\.fsh.*Line: 8\D/s);
   });
 
   // Value Set Rule
@@ -353,9 +345,7 @@ describe('StructureDefinitionExporter', () => {
     const changedElement = sd.findElement('Observation.note');
     expect(baseElement.binding).toBeUndefined();
     expect(changedElement.binding).toBeUndefined();
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: Codeless\.fsh.*Line: 6\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: Codeless\.fsh.*Line: 6\D/s);
   });
 
   it('should not override a binding with a less strict binding', () => {
@@ -378,9 +368,7 @@ describe('StructureDefinitionExporter', () => {
       'http://hl7.org/fhir/ValueSet/observation-category'
     );
     expect(changedElement.binding.strength).toBe('preferred');
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: Strict\.fsh.*Line: 9\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: Strict\.fsh.*Line: 9\D/s);
   });
 
   // Only Rule
@@ -540,9 +528,7 @@ describe('StructureDefinitionExporter', () => {
 
     expect(baseValue.type).toHaveLength(11);
     expect(constrainedValue.type).toHaveLength(11);
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: Only\.fsh.*Line: 10\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: Only\.fsh.*Line: 10\D/s);
   });
 
   // Fixed Value Rule
@@ -585,9 +571,7 @@ describe('StructureDefinitionExporter', () => {
 
     expect(baseCode.patternCodeableConcept).toBeUndefined();
     expect(fixedCode.patternCodeableConcept).toBeUndefined(); // Code remains unset
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: Fixed\.fsh.*Line: 4\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: Fixed\.fsh.*Line: 4\D/s);
   });
 
   // Contains Rule
@@ -769,9 +753,7 @@ describe('StructureDefinitionExporter', () => {
 
     expect(sd.elements.length).toBe(baseStructDef.elements.length);
     expect(barSlice).toBeUndefined();
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: NoSlice\.fsh.*Line: 6\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: NoSlice\.fsh.*Line: 6\D/s);
   });
 
   // CaretValueRule
@@ -810,9 +792,7 @@ describe('StructureDefinitionExporter', () => {
     const baseStatus = baseStructDef.findElement('Observation.status');
 
     expect(status.short).toBe(baseStatus.short);
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: InvalidValue\.fsh.*Line: 6\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidValue\.fsh.*Line: 6\D/s);
   });
 
   it('should apply a CaretValueRule on an element without a path', () => {
@@ -843,9 +823,7 @@ describe('StructureDefinitionExporter', () => {
     const baseStructDef = resolve('Observation');
 
     expect(sd.description).toBe(baseStructDef.description);
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: InvalidValue\.fsh.*Line: 6\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: InvalidValue\.fsh.*Line: 6\D/s);
   });
 
   // validateStructureDefinition

--- a/test/import/FSHImporter.Extension.test.ts
+++ b/test/import/FSHImporter.Extension.test.ts
@@ -92,7 +92,7 @@ describe('FSHImporter', () => {
         `;
 
         importText(input, 'Dupe.fsh');
-        expect(loggerSpy.getMessageAtIndex(1, true)).toMatch(/File: Dupe\.fsh.*Line: 7\D/s);
+        expect(loggerSpy.getMessageAtIndex(-2)).toMatch(/File: Dupe\.fsh.*Line: 7\D/s);
         expect(loggerSpy.getLastMessage()).toMatch(/File: Dupe\.fsh.*Line: 8\D/s);
       });
     });

--- a/test/import/FSHImporter.Extension.test.ts
+++ b/test/import/FSHImporter.Extension.test.ts
@@ -6,12 +6,9 @@ import {
   assertCaretValueRule
 } from '../testhelpers/asserts';
 import { importText } from '../../src/import';
-import { logger } from '../../src/utils/FSHLogger';
-import { LoggerSpy } from '../testhelpers/loggerSpy';
+import { loggerSpy } from '../testhelpers/loggerSpy';
 
 describe('FSHImporter', () => {
-  const loggerSpy = new LoggerSpy(logger);
-
   describe('Extension', () => {
     describe('#sdMetadata', () => {
       it('should parse the simplest possible extension', () => {

--- a/test/import/FSHImporter.Extension.test.ts
+++ b/test/import/FSHImporter.Extension.test.ts
@@ -7,13 +7,10 @@ import {
 } from '../testhelpers/asserts';
 import { importText } from '../../src/import';
 import { logger } from '../../src/utils/FSHLogger';
+import { LoggerSpy } from '../testhelpers/loggerSpy';
 
 describe('FSHImporter', () => {
-  let mockWriter: jest.SpyInstance<boolean, [any, string, ((error: Error) => void)?]>;
-
-  beforeAll(() => {
-    mockWriter = jest.spyOn(logger.transports[0], 'write');
-  });
+  const loggerSpy = new LoggerSpy(logger);
 
   describe('Extension', () => {
     describe('#sdMetadata', () => {
@@ -98,12 +95,8 @@ describe('FSHImporter', () => {
         `;
 
         importText(input, 'Dupe.fsh');
-        expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 2][0].message).toMatch(
-          /File: Dupe\.fsh.*Line: 7\D/s
-        );
-        expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-          /File: Dupe\.fsh.*Line: 8\D/s
-        );
+        expect(loggerSpy.getMessageAtIndex(1, true)).toMatch(/File: Dupe\.fsh.*Line: 7\D/s);
+        expect(loggerSpy.getLastMessage()).toMatch(/File: Dupe\.fsh.*Line: 8\D/s);
       });
     });
 

--- a/test/import/FSHImporter.Instance.test.ts
+++ b/test/import/FSHImporter.Instance.test.ts
@@ -2,13 +2,10 @@ import { importText } from '../../src/import';
 import { assertFixedValueRule } from '../testhelpers/asserts';
 import { FshCode } from '../../src/fshtypes';
 import { logger } from '../../src/utils/FSHLogger';
+import { LoggerSpy } from '../testhelpers/loggerSpy';
 
 describe('FSHImporter', () => {
-  let mockWriter: jest.SpyInstance<boolean, [any, string, ((error: Error) => void)?]>;
-
-  beforeAll(() => {
-    mockWriter = jest.spyOn(logger.transports[0], 'write');
-  });
+  const loggerSpy = new LoggerSpy(logger);
 
   describe('Instance', () => {
     describe('#instanceOf', () => {
@@ -55,9 +52,7 @@ describe('FSHImporter', () => {
 
         const result = importText(input, 'Missing.fsh');
         expect(result.instances.size).toBe(0);
-        expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-          /File: Missing\.fsh.*Line: 2 - 3\D/s
-        );
+        expect(loggerSpy.getLastMessage()).toMatch(/File: Missing\.fsh.*Line: 2 - 3\D/s);
       });
     });
 
@@ -131,12 +126,8 @@ describe('FSHImporter', () => {
         `;
 
         importText(input, 'Dupe.fsh');
-        expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 2][0].message).toMatch(
-          /File: Dupe\.fsh.*Line: 5\D/s
-        );
-        expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-          /File: Dupe\.fsh.*Line: 6\D/s
-        );
+        expect(loggerSpy.getMessageAtIndex(1, true)).toMatch(/File: Dupe\.fsh.*Line: 5\D/s);
+        expect(loggerSpy.getLastMessage()).toMatch(/File: Dupe\.fsh.*Line: 6\D/s);
       });
     });
   });

--- a/test/import/FSHImporter.Instance.test.ts
+++ b/test/import/FSHImporter.Instance.test.ts
@@ -123,7 +123,7 @@ describe('FSHImporter', () => {
         `;
 
         importText(input, 'Dupe.fsh');
-        expect(loggerSpy.getMessageAtIndex(1, true)).toMatch(/File: Dupe\.fsh.*Line: 5\D/s);
+        expect(loggerSpy.getMessageAtIndex(-2)).toMatch(/File: Dupe\.fsh.*Line: 5\D/s);
         expect(loggerSpy.getLastMessage()).toMatch(/File: Dupe\.fsh.*Line: 6\D/s);
       });
     });

--- a/test/import/FSHImporter.Instance.test.ts
+++ b/test/import/FSHImporter.Instance.test.ts
@@ -1,12 +1,9 @@
 import { importText } from '../../src/import';
 import { assertFixedValueRule } from '../testhelpers/asserts';
 import { FshCode } from '../../src/fshtypes';
-import { logger } from '../../src/utils/FSHLogger';
-import { LoggerSpy } from '../testhelpers/loggerSpy';
+import { loggerSpy } from '../testhelpers/loggerSpy';
 
 describe('FSHImporter', () => {
-  const loggerSpy = new LoggerSpy(logger);
-
   describe('Instance', () => {
     describe('#instanceOf', () => {
       it('should parse the simplest possible instance', () => {

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -149,7 +149,7 @@ describe('FSHImporter', () => {
         `;
 
         importText(input, 'Dupe.fsh');
-        expect(loggerSpy.getMessageAtIndex(1, true)).toMatch(/File: Dupe\.fsh.*Line: 7\D/s);
+        expect(loggerSpy.getMessageAtIndex(-2)).toMatch(/File: Dupe\.fsh.*Line: 7\D/s);
         expect(loggerSpy.getLastMessage()).toMatch(/File: Dupe\.fsh.*Line: 8\D/s);
       });
     });

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -9,12 +9,9 @@ import {
 } from '../testhelpers/asserts';
 import { importText } from '../../src/import';
 import { FshCode, FshQuantity, FshRatio } from '../../src/fshtypes';
-import { logger } from '../../src/utils/FSHLogger';
-import { LoggerSpy } from '../testhelpers/loggerSpy';
+import { loggerSpy } from '../testhelpers/loggerSpy';
 
 describe('FSHImporter', () => {
-  const loggerSpy = new LoggerSpy(logger);
-
   describe('Profile', () => {
     describe('#sdMetadata', () => {
       it('should parse the simplest possible profile', () => {

--- a/test/import/FSHImporter.Profile.test.ts
+++ b/test/import/FSHImporter.Profile.test.ts
@@ -10,13 +10,10 @@ import {
 import { importText } from '../../src/import';
 import { FshCode, FshQuantity, FshRatio } from '../../src/fshtypes';
 import { logger } from '../../src/utils/FSHLogger';
+import { LoggerSpy } from '../testhelpers/loggerSpy';
 
 describe('FSHImporter', () => {
-  let mockWriter: jest.SpyInstance<boolean, [any, string, ((error: Error) => void)?]>;
-
-  beforeAll(() => {
-    mockWriter = jest.spyOn(logger.transports[0], 'write');
-  });
+  const loggerSpy = new LoggerSpy(logger);
 
   describe('Profile', () => {
     describe('#sdMetadata', () => {
@@ -155,12 +152,8 @@ describe('FSHImporter', () => {
         `;
 
         importText(input, 'Dupe.fsh');
-        expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 2][0].message).toMatch(
-          /File: Dupe\.fsh.*Line: 7\D/s
-        );
-        expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-          /File: Dupe\.fsh.*Line: 8\D/s
-        );
+        expect(loggerSpy.getMessageAtIndex(1, true)).toMatch(/File: Dupe\.fsh.*Line: 7\D/s);
+        expect(loggerSpy.getLastMessage()).toMatch(/File: Dupe\.fsh.*Line: 8\D/s);
       });
     });
 
@@ -852,9 +845,7 @@ describe('FSHImporter', () => {
         const result = importText(input, 'Obeys.fsh');
         const profile = result.profiles.get('ObservationProfile');
         expect(profile.rules).toHaveLength(0);
-        expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-          /File: Obeys\.fsh.*Line: 4\D/s
-        );
+        expect(loggerSpy.getLastMessage()).toMatch(/File: Obeys\.fsh.*Line: 4\D/s);
       });
     });
   });

--- a/test/import/FSHImporter.test.ts
+++ b/test/import/FSHImporter.test.ts
@@ -1,10 +1,7 @@
 import { importText, FSHImporter, FSHDocument } from '../../src/import';
-import { logger } from '../../src/utils/FSHLogger';
-import { LoggerSpy } from '../testhelpers/loggerSpy';
+import { loggerSpy } from '../testhelpers/loggerSpy';
 
 describe('FSHImporter', () => {
-  const loggerSpy = new LoggerSpy(logger);
-
   it('should default filename to blank string', () => {
     const input = '';
     const result = importText(input);

--- a/test/import/FSHImporter.test.ts
+++ b/test/import/FSHImporter.test.ts
@@ -1,12 +1,9 @@
 import { importText, FSHImporter, FSHDocument } from '../../src/import';
 import { logger } from '../../src/utils/FSHLogger';
+import { LoggerSpy } from '../testhelpers/loggerSpy';
 
 describe('FSHImporter', () => {
-  let mockWriter: jest.SpyInstance<boolean, [any, string, ((error: Error) => void)?]>;
-
-  beforeAll(() => {
-    mockWriter = jest.spyOn(logger.transports[0], 'write');
-  });
+  const loggerSpy = new LoggerSpy(logger);
 
   it('should default filename to blank string', () => {
     const input = '';
@@ -47,9 +44,7 @@ describe('FSHImporter', () => {
     Pizza: Large
     `;
     importText(input, 'Pizza.fsh');
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: Pizza\.fsh.*Line: 3\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: Pizza\.fsh.*Line: 3\D/s);
   });
 
   it('should report extraneous input errors from antlr', () => {
@@ -58,8 +53,6 @@ describe('FSHImporter', () => {
     Parent: Spacious
     `;
     importText(input, 'Space.fsh');
-    expect(mockWriter.mock.calls[mockWriter.mock.calls.length - 1][0].message).toMatch(
-      /File: Space\.fsh.*Line: 2\D/s
-    );
+    expect(loggerSpy.getLastMessage()).toMatch(/File: Space\.fsh.*Line: 2\D/s);
   });
 });

--- a/test/testhelpers/loggerSpy.ts
+++ b/test/testhelpers/loggerSpy.ts
@@ -1,11 +1,7 @@
-import { Logger } from 'winston';
+import { logger } from '../../src/utils/FSHLogger';
 
-export class LoggerSpy {
-  private mockWriter: jest.SpyInstance<boolean, [any, string, ((error: Error) => void)?]>;
-
-  constructor(logger: Logger) {
-    this.mockWriter = jest.spyOn(logger.transports[0], 'write');
-  }
+class LoggerSpy {
+  private mockWriter = jest.spyOn(logger.transports[0], 'write');
 
   getMessageAtIndex(index: number, reverse = false): string {
     const i = reverse ? this.mockWriter.mock.calls.length - index - 1 : index;
@@ -20,3 +16,5 @@ export class LoggerSpy {
     return this.getMessageAtIndex(0, true);
   }
 }
+
+export const loggerSpy = new LoggerSpy();

--- a/test/testhelpers/loggerSpy.ts
+++ b/test/testhelpers/loggerSpy.ts
@@ -3,8 +3,8 @@ import { logger } from '../../src/utils/FSHLogger';
 class LoggerSpy {
   private mockWriter = jest.spyOn(logger.transports[0], 'write');
 
-  getMessageAtIndex(index: number, reverse = false): string {
-    const i = reverse ? this.mockWriter.mock.calls.length - index - 1 : index;
+  getMessageAtIndex(index: number): string {
+    const i = index < 0 ? this.mockWriter.mock.calls.length + index : index;
     return this.mockWriter.mock.calls[i][0].message;
   }
 
@@ -13,7 +13,7 @@ class LoggerSpy {
   }
 
   getLastMessage(): string {
-    return this.getMessageAtIndex(0, true);
+    return this.getMessageAtIndex(-1);
   }
 }
 

--- a/test/testhelpers/loggerSpy.ts
+++ b/test/testhelpers/loggerSpy.ts
@@ -1,0 +1,22 @@
+import { Logger } from 'winston';
+
+export class LoggerSpy {
+  private mockWriter: jest.SpyInstance<boolean, [any, string, ((error: Error) => void)?]>;
+
+  constructor(logger: Logger) {
+    this.mockWriter = jest.spyOn(logger.transports[0], 'write');
+  }
+
+  getMessageAtIndex(index: number, reverse = false): string {
+    const i = reverse ? this.mockWriter.mock.calls.length - index - 1 : index;
+    return this.mockWriter.mock.calls[i][0].message;
+  }
+
+  getFirstMessage(): string {
+    return this.getMessageAtIndex(0);
+  }
+
+  getLastMessage(): string {
+    return this.getMessageAtIndex(this.mockWriter.mock.calls.length - 1);
+  }
+}

--- a/test/testhelpers/loggerSpy.ts
+++ b/test/testhelpers/loggerSpy.ts
@@ -17,6 +17,6 @@ export class LoggerSpy {
   }
 
   getLastMessage(): string {
-    return this.getMessageAtIndex(this.mockWriter.mock.calls.length - 1);
+    return this.getMessageAtIndex(0, true);
   }
 }


### PR DESCRIPTION
Adds a wrapper class to the Jest Spy functionality, to clean up the tests a bit. This doesn't change any functionality at all. If you run the tests and they pass, we're good to go. Just let me know if there's any feedback you have on the implementation itself.