### PR TITLE
Extension value[x] bug

### DIFF
--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -156,8 +156,8 @@ export class StructureDefinition {
       newMatchingElements = matchingElements.filter(e => e.path.startsWith(fhirPathString));
 
       if (newMatchingElements.length === 0 && matchingElements.length === 1) {
-        // If we did not find an [x] element, and there was previously only one match,
-        // We want to unfold that match and dig deeper into it
+        // If there was previously only one match,
+        // we want to unfold that match and dig deeper into it
         unfoldedElements = matchingElements[0].unfold(resolve);
         if (unfoldedElements.length > 0) {
           // Only get the children that match our path
@@ -166,7 +166,8 @@ export class StructureDefinition {
       }
 
       if (newMatchingElements.length === 0) {
-        // If we fail to find any matches, first try to find the appropriate [x] element
+        // If we fail to find any matches, try to find the appropriate [x] element
+        // from previous matches or from newly unfolded elements
         // Ex: valueString -> value[x]
         const matchingSlice = this.sliceMatchingValueX(fhirPathString, [
           ...matchingElements,

--- a/src/fhirtypes/StructureDefinition.ts
+++ b/src/fhirtypes/StructureDefinition.ts
@@ -148,13 +148,17 @@ export class StructureDefinition {
     let fhirPathString = this.type;
     let matchingElements = this.elements;
     let newMatchingElements: ElementDefinition[] = [];
-    let unfoldedElements: ElementDefinition[] = [];
     // Iterate over the path, filtering out elements that do not match
     for (const pathPart of parsedPath) {
       // Add the next part to the path, and see if we have matches on it
       fhirPathString += `.${pathPart.base}`;
       newMatchingElements = matchingElements.filter(e => e.path.startsWith(fhirPathString));
 
+      // TODO: If path is A.B.C, and we unfold B, but C is invalid, the unfolded
+      // elements are still on the structDef. We may want to change this to remove the elements
+      // upon error
+      // Array for tracking newly added unfolded elements
+      let unfoldedElements: ElementDefinition[] = [];
       if (newMatchingElements.length === 0 && matchingElements.length === 1) {
         // If there was previously only one match,
         // we want to unfold that match and dig deeper into it

--- a/test/fhirtypes/StructureDefinition.test.ts
+++ b/test/fhirtypes/StructureDefinition.test.ts
@@ -250,6 +250,19 @@ describe('StructureDefinition', () => {
       expect(observation.elements.length).toBe(originalLength + 1);
     });
 
+    it('should make explicit a non-existent choice element that must first be unfolded', () => {
+      const originalLength = observation.elements.length;
+      const valueQuantity = observation.findElementByPath(
+        'extension.valueQuantity',
+        getResolver(defs)
+      );
+      expect(valueQuantity).toBeDefined();
+      expect(valueQuantity.id).toBe('Observation.extension.value[x]:valueQuantity');
+      expect(valueQuantity.sliceName).toBe('valueQuantity');
+      expect(valueQuantity.path).toBe('Observation.extension.value[x]');
+      expect(observation.elements.length).toBe(originalLength + 5);
+    });
+
     it('should make explicit a non-existent choice element by child path', () => {
       const originalLength = observation.elements.length;
       const valueX = observation.findElementByPath('value[x]');


### PR DESCRIPTION
This fixes a bug that @markkramerus pointed out to me. When an element had to be unfoled and had to have a `value[x]` element resolved all in one step, the `findElementByPath` function would fail. The new test tests this case.

To see the code that led us to find this issue, clone the https://github.com/standardhealth/fsh-mcode repo and run sushi on it. The bug results from this line `* extension[EvidenceType].valueCodeableConcept from CancerDiseaseStatusEvidenceTypeVS (required)` in CancerDiseaseStatus.fsh. When sushi is on master, you should see 12 errors, the first of which says "No element found at path extension[EvidenceType].valueCodeableConcept". You will also notice in the output that the `CancerDiseaseStatusEvidenceTypeVS` does not get bound to `Observation.extension:EvidenceType.value[x]:valueCodeableConcept`. When sushi is on this branch, you should see 11 errors, and in the output you will see that `CancerDiseaseStatusEvidenceTypeVS` is bound to `Observation.extension:EvidenceType.value[x]:valueCodeableConcept`, which is the desired outcome of the problematic line.