### PR TITLE
Update docs to reflect transfer to HL7 FHIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For the best experience, developers should use [Visual Studio Code](https://code
 
 # License
 
-Copyright 2019 The MITRE Corporation
+Copyright 2019 Health Level Seven International
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/standardhealth/sushi.git"
+    "url": "https://github.com/fhir/sushi.git"
   },
   "main": "dist/app.js",
   "bin": {


### PR DESCRIPTION
This PR is in anticipation of transferring ownership of this repo to github.com/fhir.  This transfer has already been approved by SHR leadership and FHIR leadership.